### PR TITLE
Fix skills referencing bundled guides by broken relative paths instead of MCP resource URIs — Closes #5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sdlc-mcp"
-version = "2026.4.10.0"
+version = "2026.4.11.0"
 description = "SDLC pipeline for LLM agents, served as an MCP server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/sdlc/skills/implement.md
+++ b/src/sdlc/skills/implement.md
@@ -171,7 +171,7 @@ Before entering planning phase, MUST read enough of the codebase to plan confide
 - MUST check whether `.understand-anything/knowledge-graph.json` exists. If it does, MUST use the `understand-chat` skill with a query synthesized from the issue title and body to gather architectural context — component summaries, relationships, and layer assignments — that informs the planning phase by revealing which files, components, and layers are relevant to the issue. If the graph does not exist, skip this bullet and continue.
 - MUST read source files referenced in the issue's description.
 - MUST read existing tests for the affected modules.
-- MUST read the project test guide (`../test-guides/python.md`) to internalize testing conventions.
+- MUST read the MCP resource `sdlc://guides/test/python` to internalize Python testing conventions.
 - MUST read project-level instructions (`AGENTS.md`) for build tooling, documentation style, and architecture context.
 
 ### 7. Enter planning phase
@@ -180,7 +180,7 @@ The execution plan must be presented to the user for approval. It:
 
 - MUST map the issue's requirements (or unresolved review comments, on re-invocation) to concrete code changes: exact files, functions, classes, and the nature of each modification.
 - SHOULD prefer test-first ordering when applicable.
-- MUST follow the testing conventions in the project test guide (`../test-guides/python.md`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
+- MUST follow the testing conventions in the Python test guide (MCP resource `sdlc://guides/test/python`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
 - MUST include a verification section with the exact command(s) to run the test suite (see the project test guide for the runner command).
 
 ### 8. Execute after approval

--- a/src/sdlc/skills/review.md
+++ b/src/sdlc/skills/review.md
@@ -95,8 +95,8 @@ If the PR does not exist, inform the user and stop. Parse the PR title, body, br
 MUST read the following files to establish the review baseline:
 
 - `AGENTS.md` — project-level instructions, architecture context, docstring conventions.
-- `../test-guides/python.md` — Python testing conventions (if the PR touches test files).
-- Every file in `../style-guides/` — active authoring conventions.
+- Read the MCP resource `sdlc://guides/test/python` — Python testing conventions (if the PR touches test files).
+- Read every MCP resource matching `sdlc://guides/style/*` — active authoring conventions.
 
 Only the guides relevant to the changed files need to be read. For example, the test guide is only needed if the PR modifies or adds test files.
 

--- a/src/sdlc/skills/test.md
+++ b/src/sdlc/skills/test.md
@@ -56,7 +56,7 @@ An issue number MUST be provided as the sole argument (e.g., `test` with issue #
 >
 > | Language | Guide |
 > |----------|-------|
-> | Python (`.py`) | `test-guides/python.md` |
+> | Python (`.py`) | MCP resource `sdlc://guides/test/python` |
 >
 > If no guide exists for the detected language, inform the user and stop.
 

--- a/uv.lock
+++ b/uv.lock
@@ -723,7 +723,7 @@ wheels = [
 
 [[package]]
 name = "sdlc-mcp"
-version = "0.1.0"
+version = "2026.4.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Replace five broken filesystem references to the SDLC server's bundled guides in the `implement`, `test`, and `review` skill files with MCP resource URIs (`sdlc://guides/test/python`, `sdlc://guides/style/*`). The previous references used relative paths like `../test-guides/python.md` that only resolved correctly when the LLM happened to operate inside the `sdlc` repo itself; for any `uvx` or wheel install, they pointed outside the user's project or at nonexistent files, so the skills silently failed to load their guide context. The server already registers these resources, so the skills are now install-mode-agnostic and work identically whether the server runs from an editable install, a wheel install, or `uvx`. Also sync `uv.lock` with the project version bump on `main` so `uv run` no longer produces a dirty working tree on every invocation. Closes #5

## Proposed changes

### Replace broken guide filesystem paths with MCP URIs (`src/sdlc/skills/`)

Rewrite five references across three skill files to read the corresponding MCP resource URI instead of a relative filesystem path:

- `src/sdlc/skills/review.md` step 3 ("Read project guides and styles") — replace `../test-guides/python.md` with `sdlc://guides/test/python` and `../style-guides/` with the pattern `sdlc://guides/style/*` for forward compatibility as new style guides are added.
- `src/sdlc/skills/implement.md` step 6 (context-gathering checklist) — replace the project test guide reference with `sdlc://guides/test/python`.
- `src/sdlc/skills/implement.md` step 7 (planning phase requirements) — replace the project test guide reference with `sdlc://guides/test/python`.
- `src/sdlc/skills/test.md` test-guide lookup table — replace the `Guide` column's filesystem path with `sdlc://guides/test/python` for the Python row.

The bare `AGENTS.md` references in the skill files' subagent briefs are intentionally left alone — those target the *user's project* `AGENTS.md` at cwd, not the SDLC server's bundled one, and have different semantics. See the scope-boundary note in issue #5 for details.

### Sync `uv.lock` with `pyproject.toml` version bump

Commit 9d3255f on `main` bumped the project version from `0.1.0` to `2026.4.10.0` in `pyproject.toml` but did not regenerate `uv.lock`, so the lock file still carried the stale `0.1.0` entry for `sdlc-mcp`. Every `uv run` invocation detected the mismatch and auto-updated the lock file, producing a dirty working tree on every test run. Regenerate the lock-file entry so `pyproject.toml` and `uv.lock` agree and subsequent `uv run` invocations leave the tree clean. This drive-by fix is included in PR #5 because it surfaced during the rebase of this branch onto the post-merge `main` and left the working tree dirty during verification.

## Verification

Run the existing test suite:

```bash
uv run --group test pytest tests/ -x
```

Expected: 14 passed. The existing MCP resource tests (`test_test_guide_python_returns_content`, `test_style_guide_markdown_returns_content`, `test_agents_md_returns_content` in `tests/test_server.py`) already cover the contract the skill text now depends on — no new tests are added for the documentation fix. Additionally confirm the working tree stays clean after `uv run`, verifying the `uv.lock` sync.
