### PR TITLE
Instruct pr skill to describe net base..HEAD diff, not intra-PR churn — Closes #3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "sdlc-mcp"
-version = "2026.4.11.0"
+version = "2026.4.17.0"
 description = "SDLC pipeline for LLM agents, served as an MCP server"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/sdlc/skills/pr.md
+++ b/src/sdlc/skills/pr.md
@@ -29,6 +29,7 @@ This skill is part of the development workflow pipeline: `issue` → `implement`
 - MUST always create the PR as a draft -- never mark it ready for review automatically.
 - MUST NOT create the PR until the user explicitly approves the description.
 - MUST match the PR title exactly to the issue title with ` — Closes #<number>` appended.
+- MUST describe the net `<base>..HEAD` diff in the PR body, where `<base>` is the PR's base branch (discoverable via `gh pr view <number> --json baseRefName`), not the sequence of changes across the PR's commits. If a file, block, or behavior was added and later removed within the same PR (e.g., via fixup rebase or interactive history rewriting), it MUST NOT appear in the description — from the base branch's perspective it never existed.
 - MUST use a heredoc for the `gh pr create` body to avoid shell escaping issues.
 - MUST structure the PR description according to the project's PR template if one exists, otherwise the built-in format defined in this document.
 - MUST assign the PR to the current user upon creation via `gh pr edit <number> --add-assignee @me`.

--- a/uv.lock
+++ b/uv.lock
@@ -723,7 +723,7 @@ wheels = [
 
 [[package]]
 name = "sdlc-mcp"
-version = "2026.4.10.0"
+version = "2026.4.17.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary

Add an explicit Invariant to `src/sdlc/skills/pr.md` requiring that PR descriptions describe the net diff between the PR's base branch and its head, not the intra-PR sequence of commits. The rule is framed against "the PR's base branch" (discoverable via `gh pr view <number> --json baseRefName`) rather than hardcoding any specific branch name, so it remains correct on git-flow projects that target `develop`, `master`, `production`, or release branches. The motivating failure was a real incident during PR #2's description update where an LLM drafted a bullet documenting the removal of a transiently-added configuration block that never existed on `main` — the skill lacked an explicit rule to exclude such intra-PR churn. Closes #3

## Proposed changes

### Add net-diff invariant to the pr skill (`src/sdlc/skills/pr.md`)

Insert one new bullet in the Invariants list, positioned between the existing title-match invariant and the heredoc invariant (keeping content-shape invariants grouped):

> MUST describe the net `<base>..HEAD` diff in the PR body, where `<base>` is the PR's base branch (discoverable via `gh pr view <number> --json baseRefName`), not the sequence of changes across the PR's commits. If a file, block, or behavior was added and later removed within the same PR (e.g., via fixup rebase or interactive history rewriting), it MUST NOT appear in the description — from the base branch's perspective it never existed.

Placement decision: the rule lives as a top-level Invariant rather than under "Body prose rules" (section 4c) because it governs what qualifies as a correct description, not a prose-style concern, and because the motivating failure was precisely an LLM missing this rule — high visibility was a first-order requirement. Existing Invariants already include content-shape rules like the title-match rule, so the placement is consistent with the file's existing structure.

Wording decisions: the rule keeps the `gh pr view --json baseRefName` discoverability hint to give the executing LLM a concrete resolution mechanism rather than leaving "the PR's base branch" as an abstract concept; mentions both `fixup rebase` and `interactive history rewriting` because the motivating failure was a fixup rebase but the rule generalizes to any history rewriting that elides transient changes; uses `MUST`/`MUST NOT` to match the RFC 2119 convention already declared at the top of the file; and stays on a single long line per the project's Markdown style guide.

### Scope boundary

Issue #4 (`Fix pr skill merge-base fallback hardcoding "main"`) also affects `pr.md`, at a different code path (line 115, the merge-base lookup command). The two fixes are documented as independent in both issue bodies and are intentionally landed as separate PRs so they can be reviewed and reverted in isolation.

## Verification

Run the existing test suite:

```bash
uv run --group test pytest tests/ -q
```

Expected: 14 passed. The change is documentation-only — one line added to a skill markdown file that the MCP server returns verbatim. Existing `tests/test_server.py` coverage over the `sdlc_pr` tool handler continues to apply unchanged: the tool still returns the file contents, just with one more line.
