### PR TITLE
Dispatch `sdlc_implement` between fresh-implementation and feedback-remediation prompts — Closes #11

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,13 @@ sdlc/
         ├── __init__.py             # Package entry point
         ├── __main__.py             # python -m sdlc support
         ├── server.py               # FastMCP server, tool & resource registrations
+        ├── pr_state.py             # gh wrappers and PR-state dispatch for sdlc_implement
         ├── AGENTS.md               # Technical reference for agent implementations
         ├── skills/                 # Canonical skill definitions (read by server)
         │   ├── issue.md
         │   ├── implement.md
+        │   ├── implement-continue.md
+        │   ├── implement-feedback.md
         │   ├── test.md
         │   ├── commit.md
         │   ├── pr.md
@@ -129,7 +132,7 @@ sdlc/
 | Tool | Purpose |
 |------|---------|
 | `sdlc_issue` | Draft and push a GitHub issue |
-| `sdlc_implement` | Implement a GitHub issue with planning and code changes |
+| `sdlc_implement` | Implement a GitHub issue, continue an in-progress PR, or address PR review feedback |
 | `sdlc_test` | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | Stage and commit changes with atomic commits |
 | `sdlc_pr` | Review changes and create a draft pull request |

--- a/src/sdlc/AGENTS.md
+++ b/src/sdlc/AGENTS.md
@@ -13,7 +13,7 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | Tool | Stage | Purpose |
 |------|-------|---------|
 | `sdlc_issue` | 1st | Draft and push a GitHub issue |
-| `sdlc_implement` | 2nd | Implement a GitHub issue with planning and code changes |
+| `sdlc_implement` | 2nd | Implement a GitHub issue, continue an in-progress PR, or address PR review feedback |
 | `sdlc_test` | 3rd | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | 4th | Stage and commit changes with atomic commits |
 | `sdlc_pr` | 5th | Review changes and create a draft pull request |
@@ -21,7 +21,7 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | `sdlc_understand_chat` | — | Query the codebase knowledge graph |
 | `sdlc_guides_for` | — | Resolve which test or style guides apply to a list of file paths |
 
-The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine implementation.
+The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine implementation. `sdlc_implement` accepts either an issue number or a PR number and dispatches between three sibling skill prompts based on PR state: `implement` (fresh start, no PR yet), `implement-continue` (PR exists, no review feedback yet), and `implement-feedback` (PR has unresolved review threads or review-body comments).
 
 ### MCP Resources
 
@@ -139,11 +139,14 @@ sdlc/
     ├── __main__.py
     ├── server.py                    ← FastMCP server, tools, resources
     ├── guides.py                    ← Config loader, guide discovery, resolver
+    ├── pr_state.py                  ← gh wrappers and PR-state dispatch for sdlc_implement
     ├── config.json                  ← Package-default config (guide-map)
     ├── AGENTS.md                    ← you are here (canonical)
     ├── skills/                      ← Canonical skill definitions (read by server)
     │   ├── issue.md
     │   ├── implement.md
+    │   ├── implement-continue.md
+    │   ├── implement-feedback.md
     │   ├── test.md
     │   ├── commit.md
     │   ├── pr.md

--- a/src/sdlc/pr_state.py
+++ b/src/sdlc/pr_state.py
@@ -1,0 +1,247 @@
+"""GitHub PR state detection for the `sdlc_implement` MCP endpoint."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Literal
+
+
+class GhUnavailable(Exception):
+    """Raised when ``gh`` is missing, unauthenticated, or returns an unexpected error.
+
+    The dispatcher in ``server.py`` catches this and falls back to the
+    fresh-implementation prompt with a diagnostic comment so the LLM can
+    proceed manually.
+    """
+
+
+@dataclass(frozen=True)
+class Finding:
+    """A single piece of unresolved PR review feedback."""
+
+    kind: Literal["review_thread", "review_body"]
+    path: str | None
+    line: int | None
+    body: str
+    author: str | None
+
+
+@dataclass(frozen=True)
+class PrContext:
+    """PR metadata for the no-feedback (continue) flow."""
+
+    pr_number: int
+    head_ref: str
+    url: str
+
+
+@dataclass(frozen=True)
+class Findings:
+    """PR metadata plus the enumerated review feedback."""
+
+    pr_number: int
+    head_ref: str
+    url: str
+    findings: list[Finding]
+
+    def format(self) -> str:
+        """Render the findings as a human-readable block for the skill prompt."""
+        lines = [
+            f"PR: #{self.pr_number} ({self.url})",
+            f"Branch: {self.head_ref}",
+            f"Findings ({len(self.findings)}):",
+        ]
+        for index, finding in enumerate(self.findings, start=1):
+            if finding.path is not None and finding.line is not None:
+                citation = f"{finding.path}:{finding.line}"
+            elif finding.path is not None:
+                citation = finding.path
+            else:
+                citation = "(PR-level review)"
+            author = finding.author or "unknown"
+            lines.append(
+                f"  {index}. [{finding.kind}] {citation} — @{author}: {finding.body}"
+            )
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class _Repo:
+    owner: str
+    name: str
+    repo_flag: str | None
+
+
+_GRAPHQL_REVIEW_THREADS = (
+    "query($owner: String!, $repo: String!, $pr: Int!) "
+    "{ repository(owner: $owner, name: $repo) { pullRequest(number: $pr) "
+    "{ reviewThreads(first: 100) { nodes { isResolved comments(first: 1) "
+    "{ nodes { body path line author { login } } } } } } } }"
+)
+
+
+def _run_gh(args: list[str], allow_failure: bool = False) -> str | None:
+    """Invoke ``gh`` and return stdout.
+
+    Raises ``GhUnavailable`` when the binary is missing or the command exits
+    non-zero (unless ``allow_failure`` is set, in which case the function
+    returns ``None`` on non-zero exits).
+    """
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise GhUnavailable("gh executable not found on PATH") from exc
+    if result.returncode != 0:
+        if allow_failure:
+            return None
+        stderr = result.stderr.strip() or f"exit code {result.returncode}"
+        raise GhUnavailable(f"gh {' '.join(args)} failed: {stderr}")
+    return result.stdout
+
+
+def _resolve_repo() -> _Repo:
+    out = _run_gh(["repo", "view", "--json", "owner,name,isFork,parent"])
+    data = json.loads(out)
+    if data.get("isFork"):
+        parent = data["parent"]
+        owner = parent["owner"]["login"]
+        name = parent["name"]
+        return _Repo(owner=owner, name=name, repo_flag=f"{owner}/{name}")
+    return _Repo(owner=data["owner"]["login"], name=data["name"], repo_flag=None)
+
+
+def _with_repo(args: list[str], repo_flag: str | None) -> list[str]:
+    if repo_flag is None:
+        return args
+    return [*args, "--repo", repo_flag]
+
+
+def _classify_number(
+    repo: _Repo, number: int
+) -> tuple[Literal["pr", "issue", "missing"], dict | None]:
+    pr_args = ["pr", "view", str(number)]
+    pr_args = _with_repo(pr_args, repo.repo_flag)
+    pr_args += ["--json", "number,headRefName,url"]
+    pr_out = _run_gh(pr_args, allow_failure=True)
+    if pr_out is not None:
+        return "pr", json.loads(pr_out)
+    issue_args = _with_repo(["issue", "view", str(number)], repo.repo_flag)
+    issue_out = _run_gh(issue_args, allow_failure=True)
+    if issue_out is not None:
+        return "issue", None
+    return "missing", None
+
+
+def _find_linked_pr(repo: _Repo, issue_number: int) -> dict | None:
+    args = ["pr", "list"]
+    args = _with_repo(args, repo.repo_flag)
+    args += [
+        "--search", f"Closes #{issue_number}",
+        "--json", "number,headRefName,url",
+        "--jq", ".[0]",
+    ]
+    out = _run_gh(args)
+    stripped = out.strip() if out else ""
+    if not stripped or stripped == "null":
+        return None
+    return json.loads(stripped)
+
+
+def _query_review_state(
+    repo: _Repo, pr_number: int
+) -> tuple[list[Finding], list[Finding]]:
+    graphql_args = [
+        "api", "graphql",
+        "-f", f"query={_GRAPHQL_REVIEW_THREADS}",
+        "-f", f"owner={repo.owner}",
+        "-f", f"repo={repo.name}",
+        "-F", f"pr={pr_number}",
+    ]
+    graphql_out = _run_gh(graphql_args)
+    graphql_data = json.loads(graphql_out)
+    raw_threads = (
+        graphql_data.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    threads: list[Finding] = []
+    for thread in raw_threads:
+        if thread.get("isResolved"):
+            continue
+        comments = thread.get("comments", {}).get("nodes", [])
+        if not comments:
+            continue
+        comment = comments[0]
+        author = (comment.get("author") or {}).get("login")
+        threads.append(
+            Finding(
+                kind="review_thread",
+                path=comment.get("path"),
+                line=comment.get("line"),
+                body=comment.get("body", ""),
+                author=author,
+            )
+        )
+
+    reviews_args = ["pr", "view", str(pr_number)]
+    reviews_args = _with_repo(reviews_args, repo.repo_flag)
+    reviews_args += ["--json", "reviews"]
+    reviews_out = _run_gh(reviews_args)
+    reviews_data = json.loads(reviews_out)
+    body_findings: list[Finding] = []
+    for review in reviews_data.get("reviews", []):
+        body = (review.get("body") or "").strip()
+        if not body:
+            continue
+        author = (review.get("author") or {}).get("login")
+        body_findings.append(
+            Finding(
+                kind="review_body",
+                path=None,
+                line=None,
+                body=body,
+                author=author,
+            )
+        )
+    return threads, body_findings
+
+
+def dispatch(number: int) -> Findings | PrContext | None:
+    """Classify ``number`` and gather PR feedback if applicable.
+
+    Returns:
+      * ``None`` — ``number`` is an issue with no linked PR (fresh flow).
+      * ``PrContext`` — a PR is in scope but has no unresolved feedback (continue flow).
+      * ``Findings`` — a PR is in scope with unresolved feedback (feedback flow).
+
+    Raises ``GhUnavailable`` for any error, including ``number`` not being
+    a known issue or PR in the target repo.
+    """
+    repo = _resolve_repo()
+    kind, pr_meta = _classify_number(repo, number)
+    if kind == "missing":
+        raise GhUnavailable(f"#{number} is neither an open issue nor a PR")
+    if kind == "issue":
+        pr_meta = _find_linked_pr(repo, number)
+        if pr_meta is None:
+            return None
+    assert pr_meta is not None
+    pr_number = int(pr_meta["number"])
+    head_ref = pr_meta["headRefName"]
+    url = pr_meta["url"]
+    threads, body_findings = _query_review_state(repo, pr_number)
+    findings = [*threads, *body_findings]
+    if not findings:
+        return PrContext(pr_number=pr_number, head_ref=head_ref, url=url)
+    return Findings(
+        pr_number=pr_number, head_ref=head_ref, url=url, findings=findings
+    )

--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from mcp.server.fastmcp import FastMCP
 
-from sdlc import guides
+from sdlc import guides, pr_state
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = PACKAGE_DIR / "skills"
@@ -59,19 +59,43 @@ async def sdlc_issue(context: str | None = None) -> str:
 
 
 @mcp.tool()
-async def sdlc_implement(issue_number: int) -> str:
-    """Implement a GitHub issue with planning and code changes.
+async def sdlc_implement(number: int) -> str:
+    """Implement a GitHub issue or address feedback on an open PR.
 
     Use when the user says "implement", "implement #N", or similar.
-    Fetches the issue, creates a branch, gathers context, and enters
-    planning phase before writing code. On re-invocation after a PR
-    exists, addresses unresolved review feedback.
+    Pass an issue number for a fresh start; pass a PR number to continue
+    work on an in-progress PR or to address unresolved review feedback.
+
+    The endpoint inspects the GitHub state for ``number`` and returns one
+    of three skill prompts: the fresh-implementation prompt, the
+    continue-on-existing-branch prompt, or the PR-feedback-remediation
+    prompt. If ``gh`` is unavailable, falls back to the fresh prompt with
+    a diagnostic note.
 
     Args:
-        issue_number: The GitHub issue number to implement.
+        number: An issue number or an open PR number.
     """
-    skill = _read_skill("implement")
-    return f"{skill}\n---\n\nTarget issue: #{issue_number}"
+    try:
+        state = pr_state.dispatch(number)
+    except pr_state.GhUnavailable as exc:
+        skill = _read_skill("implement")
+        return (
+            f"{skill}\n---\n\nTarget: #{number}\n\n"
+            f"<!-- diagnostic: PR state could not be determined ({exc}); "
+            "falling back to fresh-implementation prompt. -->"
+        )
+    if state is None:
+        skill = _read_skill("implement")
+        return f"{skill}\n---\n\nTarget issue: #{number}"
+    if isinstance(state, pr_state.Findings):
+        skill = _read_skill("implement-feedback")
+        return f"{skill}\n---\n\nTarget: #{number}\n{state.format()}"
+    skill = _read_skill("implement-continue")
+    return (
+        f"{skill}\n---\n\n"
+        f"Target PR: #{state.pr_number} ({state.url})\n"
+        f"Branch: {state.head_ref}"
+    )
 
 
 @mcp.tool()

--- a/src/sdlc/skills/implement-continue.md
+++ b/src/sdlc/skills/implement-continue.md
@@ -1,0 +1,181 @@
+---
+name: implement-continue
+description: >
+  Continue an in-progress GitHub PR that has no review feedback yet.
+  Invoked by the `sdlc_implement` MCP endpoint when a PR is in scope and
+  has zero unresolved review threads and zero non-empty review-body
+  comments. Checks out the PR branch, identifies remaining work against
+  the linked issue, and enters planning phase to design the next slice
+  of execution.
+subagent:
+  support: optional
+  type: general-purpose
+  artifacts:
+    - branch_name
+    - pr_url
+    - pr_number
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Implement Continue Skill
+
+Pick up an in-progress PR that has no review feedback yet. Check out the PR branch, identify what remains to be done against the linked issue, and enter planning phase to design the next slice of execution.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when a PR is in scope but has zero unresolved review threads and zero non-empty review-body comments. Fresh-start work is routed to the `implement` skill; PR review feedback is routed to the `implement-feedback` skill.
+
+## Implementation Notes
+
+**Planning phase** is a structured approval workflow. When instructions reference "enter planning phase," execute it according to your coding assistant tool:
+
+**Claude Code:**
+- MUST invoke the `EnterPlanMode` tool to present the plan in the planning interface.
+- MUST wait for the tool to collect user approval before returning control to you.
+- After approval, MUST implement exactly as specified in the approved plan.
+
+**Other LLM assistants:**
+- MUST output the plan as clearly structured text with explicit sections (Overview, Files to Modify, Implementation Steps, Testing Strategy, Verification Command).
+- MUST append an explicit approval request: "Does this plan look good? Please approve to proceed, request changes, or reject."
+- MUST wait for the user's explicit approval before implementing.
+- MUST NOT proceed without clear user confirmation.
+
+## Invariants
+
+- MUST check out the PR branch before any other action; never start work from `main` or an unrelated branch.
+- MUST identify the linked issue via GitHub's `closingIssuesReferences` GraphQL connection; if it returns none, fall back to parsing the PR body for `Closes #N` (or `Fixes #N`, `Resolves #N`). Read the issue body to scope the remaining work.
+- MUST enter planning phase and receive user approval before writing any code.
+- MUST NOT create or modify files outside the scope of the approved plan.
+- MUST NOT proceed to the next pipeline step autonomously -- always prompt the user.
+- MUST use the `understand-chat` skill to query the knowledge graph for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
+## Arguments
+
+The MCP endpoint supplies the PR number, branch name, and PR URL appended below this skill prompt. The agent MUST consume those values rather than re-deriving them.
+
+## Subagent Execution (Optional)
+
+This skill MAY be executed in an isolated subagent to preserve parent context. When invoked with a `--subagent` flag, execute according to your tool:
+
+**Claude Code:**
+- MUST spawn a general-purpose subagent using the Agent tool with this brief:
+  > You are executing the **`implement-continue`** skill from the SDLC pipeline (`issue` → `implement` → `test` → `commit` → `pr` → `review`).
+  > 1. Read the project instructions in `AGENTS.md`
+  > 2. Read and execute the complete workflow defined in this skill's markdown
+  > 3. Follow every step faithfully, especially the Invariants section
+  > 4. Return a structured summary: accomplishments, key artifacts (branch name, PR URL, remaining work), and the next pipeline step prompt from the skill
+
+- When the subagent returns, reproduce its full output to the user exactly as written — do not summarize, condense, paraphrase, or omit sections. Do not repeat work or add your own commentary.
+
+**Other LLM assistants:**
+- Subagent execution may not be supported in your tool. Execute the skill inline following the normal workflow.
+
+## Workflow
+
+### Checklist
+
+1. Resolve target repository
+2. Check out the PR branch
+3. Identify the linked issue
+4. Diff the issue against the current branch state
+5. Gather context
+6. Enter planning phase
+7. Execute after approval
+8. Prompt the user to move onto the test or commit step
+
+### 1. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. If the repo is not a fork, the target repo is the current repo and no `--repo` flag is needed.
+
+All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Check out the PR branch
+
+The MCP endpoint supplied the branch name. Fetch and check it out:
+
+```bash
+git fetch origin <branch> && git checkout <branch>
+```
+
+If the working tree has uncommitted changes that would conflict with the checkout, stop and ask the user how to proceed (stash, discard, or commit first).
+
+### 3. Identify the linked issue
+
+Query GitHub's `closingIssuesReferences` connection — this is the authoritative set of issues that close when the PR merges, regardless of whether they were linked via a `Closes #N` keyword or the GitHub UI. It is deterministic and does not depend on parsing prose:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        closingIssuesReferences(first: 10) { nodes { number title } }
+      }
+    }
+  }
+' -f owner='<owner>' -f repo='<repo>' -F pr=<pr-number>
+```
+
+If the query returns one or more nodes, use them. If it returns none, fall back to parsing the PR body for `Closes #N` (or `Fixes #N`, `Resolves #N`):
+
+```bash
+gh pr view <pr-number> --repo <target> --json body --jq '.body'
+```
+
+Then fetch the issue body so the remaining work can be scoped against it:
+
+```bash
+gh issue view <issue-number> --repo <target>
+```
+
+If neither surface yields a linked issue, ask the user which issue the PR is implementing.
+
+### 4. Diff the issue against the current branch state
+
+Compare the issue's expected outcome against what is already implemented on the branch. Read the diff between the branch and `main` to see what has been done so far:
+
+```bash
+git log --oneline main..HEAD
+git diff main...HEAD --stat
+```
+
+The remaining work is whatever the issue's expected outcome calls for that is NOT yet present on the branch.
+
+### 5. Gather context
+
+Before entering planning phase, MUST read enough of the codebase to plan confidently:
+
+- MUST check whether `.understand-anything/knowledge-graph.json` exists. If it does, MUST use the `understand-chat` skill with a query synthesized from the issue title and the remaining work to gather architectural context. If the graph does not exist, skip this bullet and continue.
+- MUST read source files referenced in the issue's description and any new files added on the branch.
+- MUST read existing tests for the affected modules.
+- MUST resolve applicable test guides by calling `sdlc_guides_for` with the candidate or referenced source-file paths and `kind="test"`, then read every returned URI to internalize the relevant testing conventions.
+- MUST read project-level instructions (`AGENTS.md`) for build tooling, documentation style, and architecture context.
+
+### 6. Enter planning phase
+
+The execution plan must be presented to the user for approval. It:
+
+- MUST map the *remaining* work (not the work already done on the branch) to concrete code changes: exact files, functions, classes, and the nature of each modification.
+- SHOULD prefer test-first ordering when applicable.
+- MUST follow the testing conventions in the test guides resolved via `sdlc_guides_for` (kind=`test`).
+- MUST include a verification section with the exact command(s) to run the test suite.
+
+### 7. Execute after approval
+
+Once the user approves the plan, implement each step sequentially.
+
+### 8. Prompt the user to move onto the test or commit step
+
+The user MUST be prompted with the next pipeline step: "Ready to generate tests? Run the `test` skill with the issue number to analyze coverage and write tests. Or ready to commit? Run the `commit` skill to stage and commit the changes." DO NOT proceed on your own.
+
+## Edge Cases
+
+- **Branch checkout fails (uncommitted changes):** Stop and ask the user how to handle the conflict.
+- **Branch checkout fails (missing remote ref):** Stop and report the situation; the supplied branch name may be stale.
+- **No linked issue (`closingIssuesReferences` returns none AND the PR body has no `Closes` reference):** Ask the user which issue the PR addresses; do not guess.
+- **Linked issue is closed:** Surface the discrepancy and ask the user whether the work should still proceed.
+- **Branch is fully caught up to the issue's expected outcome:** Inform the user, recommend running `sdlc_test` or `sdlc_pr` next, and stop.

--- a/src/sdlc/skills/implement-feedback.md
+++ b/src/sdlc/skills/implement-feedback.md
@@ -1,0 +1,198 @@
+---
+name: implement-feedback
+description: >
+  Address unresolved PR review feedback for an open pull request.
+  Invoked by the `sdlc_implement` MCP endpoint when an open PR has
+  unresolved review threads or non-empty review-body comments. Walks
+  through findings sequentially with per-finding evaluation, approval,
+  and fixup-commit guidance.
+subagent:
+  support: optional
+  type: general-purpose
+  artifacts:
+    - branch_name
+    - pr_url
+    - pr_number
+    - findings_addressed
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Implement Feedback Skill
+
+Walk through unresolved PR review feedback systematically, one finding at a time, with per-finding evaluation and approval gates. Generate ready-to-execute fixup-commit commands after each remediation; do not auto-commit.
+
+## Pipeline Context
+
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when an open PR has unresolved review threads or non-empty review-body comments. Fresh-start work is routed to the `implement` skill; mid-implementation continuation is routed to the `implement-continue` skill.
+
+## Implementation Notes
+
+This skill does **not** use the structured planning interface (`EnterPlanMode` for Claude Code, structured-plan-text for other LLM assistants). Instead, each finding gets its own inline mini-plan and approval gate during the sequential walkthrough. Reserve the planning interface for end-to-end implementation tasks; per-finding remediation works better as a conversational loop.
+
+## Invariants
+
+- MUST verify the server-supplied finding enumeration by re-querying both review threads AND review-body comments before walking through findings.
+- MUST order findings by the canonical severity sequence (correctness → code quality → integration tests → unit tests → style → docs).
+- MUST track findings as a todo list, one task per finding, kept visible to the user.
+- MUST present findings sequentially. For each finding the agent MUST restate the finding with `file:line` citation, evaluate correctness/relevance, propose one or more solutions with their implications, recommend one option, and wait for explicit user approval before editing.
+- MUST NOT auto-commit. After each approved remediation, MUST emit a copy-paste-able `git commit --fixup=<sha>` block mapping each touched file back to the commit on the branch that owns that surface. The agent MUST NOT execute these commands.
+- MUST prompt the user to run `sdlc_commit` when they are ready to commit the accumulated remediations.
+- MUST NOT proceed to the next pipeline step autonomously.
+- MUST use the `understand-chat` skill to query the knowledge graph for context gathering when `.understand-anything/knowledge-graph.json` exists.
+
+## Arguments
+
+The MCP endpoint supplies the PR number, branch name, PR URL, and an enumerated list of findings (review threads and review-body comments) appended below this skill prompt. The agent MUST treat that enumeration as a starting point and re-query (step 3) to confirm completeness before walking through findings.
+
+## Subagent Execution (Optional)
+
+This skill MAY be executed in an isolated subagent to preserve parent context. When invoked with a `--subagent` flag, execute according to your tool:
+
+**Claude Code:**
+- MUST spawn a general-purpose subagent using the Agent tool with this brief:
+  > You are executing the **`implement-feedback`** skill from the SDLC pipeline (`issue` → `implement` → `test` → `commit` → `pr` → `review`).
+  > 1. Read the project instructions in `AGENTS.md`
+  > 2. Read and execute the complete workflow defined in this skill's markdown
+  > 3. Follow every step faithfully, especially the Invariants section
+  > 4. Return a structured summary: accomplishments, findings addressed, fixup-commit commands emitted, and the next pipeline step prompt from the skill
+
+- When the subagent returns, reproduce its full output to the user exactly as written — do not summarize, condense, paraphrase, or omit sections. The user needs to review the complete output to give informed approval. Do not repeat work or add your own commentary.
+
+**Other LLM assistants:**
+- Subagent execution may not be supported in your tool. Execute the skill inline following the normal workflow.
+
+## Workflow
+
+### Checklist
+
+1. Resolve target repository
+2. Check out the PR branch
+3. Verify findings
+4. Order findings by severity
+5. Track findings as a todo list
+6. Gather context
+7. Walk through findings sequentially
+8. Emit fixup commands after each remediation
+9. Prompt the user to run `sdlc_commit`
+
+### 1. Resolve target repository
+
+```bash
+gh repo view --json isFork,parent
+```
+
+If `isFork` is `true`, use upstream `<owner>/<name>` as the target. All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Check out the PR branch
+
+The MCP endpoint supplied the branch name. Fetch and check it out:
+
+```bash
+git fetch origin <branch> && git checkout <branch>
+```
+
+If the working tree has uncommitted changes that would conflict with the checkout, stop and ask the user how to proceed.
+
+### 3. Verify findings
+
+The server-supplied enumeration is the starting point but MUST be verified. Re-query both surfaces:
+
+```bash
+gh api graphql -f query='
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        reviewThreads(first: 100) {
+          nodes { isResolved comments(first: 1) { nodes { body path line author { login } } } }
+        }
+      }
+    }
+  }
+' -f owner='<owner>' -f repo='<repo>' -F pr=<pr-number>
+
+gh pr view <pr-number> --repo <target> --json reviews
+```
+
+**Definition of "unresolved review comment":** A review comment is unresolved when its thread is literally marked as unresolved in GitHub's review UI (i.e., the thread has not been clicked "Resolve conversation"). This is a binary GitHub state, not a judgment call. Use the `isResolved` field on review-thread nodes to determine this. An unresolved thread means the reviewer intentionally left it open — the skill MUST read each unresolved comment, understand what the reviewer is asking for, and plan changes to address it. Do not dismiss unresolved comments as already handled without verifying the reviewer's intent.
+
+Findings come from two surfaces and BOTH MUST be enumerated:
+
+- **Review threads** — inline comments left on specific lines of the diff. The correctness review in particular often carries its findings here rather than in the PR-level review body.
+- **Review-body comments** — PR-level comments left as part of a review summary. Skip empty bodies (an APPROVED review with no body is not a finding).
+
+If the verification surfaces findings the server's enumeration missed, add them to the working set. If it surfaces fewer (e.g., a reviewer resolved a thread between the server query and now), drop them.
+
+### 4. Order findings by severity
+
+Sort the verified findings by the canonical severity sequence so downstream remediations may be obviated by upstream fixes:
+
+1. Correctness bugs in source
+2. Code quality / hygiene in source
+3. Test issues — integration tests
+4. Test issues — unit tests
+5. Stylistic issues
+6. Documentation issues
+
+**Rationale:** A correctness fix may rewrite the surface a quality finding targeted, and a source-code rename may invalidate a doc finding verbatim. Front-loading impact prevents wasted churn.
+
+### 5. Track findings as a todo list
+
+Create one task per finding so the user can see progress. The task description SHOULD include the finding's `file:line` citation and a short summary so each task is self-contained when read out of context.
+
+### 6. Gather context
+
+Before walking through findings, MUST read enough of the codebase to evaluate them confidently:
+
+- MUST check whether `.understand-anything/knowledge-graph.json` exists. If it does, MUST use the `understand-chat` skill with a query synthesized from the highest-severity finding to gather architectural context. If the graph does not exist, skip this bullet and continue.
+- MUST read source files referenced in any finding's `file:line` citation.
+- MUST read existing tests for the affected modules.
+- MUST resolve applicable test guides by calling `sdlc_guides_for` with the candidate or referenced source-file paths and `kind="test"`, then read every returned URI to internalize the relevant testing conventions.
+- MUST read project-level instructions (`AGENTS.md`) for build tooling, documentation style, and architecture context.
+
+### 7. Walk through findings sequentially
+
+For each finding, in severity order:
+
+1. **Restate the finding** with its `file:line` citation, the reviewer's name, and the exact body text. Mark the corresponding todo as in-progress.
+2. **Evaluate correctness/relevance.** Reviewers can be wrong or out of date. Read the code at the cited location. State whether the finding is valid, partially valid, or stale, and explain why.
+3. **Propose one or more solutions** with their implications. Call out a recommended option grounded in the PR's objectives.
+4. **Wait for explicit user approval** before editing. Allow the user to push back, ask clarifying questions, or pick a different option. The agent MUST NOT edit any file before approval is given.
+5. **Implement the approved option.** Edit only the files in scope of the approved option.
+6. **Mark the todo complete** after the user confirms the remediation looks right (or after step 8's fixup-command block has been emitted, whichever the user prefers).
+
+### 8. Emit fixup commands after each remediation
+
+After each approved remediation, map every touched file back to the commit on the branch that owns that surface, and emit a copy-paste-able block of `git commit --fixup=<sha>` commands. To find the owning commit:
+
+```bash
+git log --oneline main..HEAD -- <touched-file>
+```
+
+The most recent commit touching the file is usually the right target. Include the target commit's subject as a trailing comment so the user can sanity-check the mapping:
+
+```bash
+git add path/to/touched/file.py
+git commit --fixup=<sha>      # <commit subject as appears in git log>
+```
+
+**Fixup vs new commit:** Prefer `git commit --fixup=<sha>` when the remediation touches code that already belongs to an existing commit on the branch. An autosquash rebase later folds these in cleanly. Net-new commits are warranted ONLY when the remediation introduces an entirely new subsystem, feature, or concept. If the remediation *replaces* something already in a prior commit, fixup that prior commit instead.
+
+The agent MUST NOT execute these commands. The user reviews and runs them.
+
+### 9. Prompt the user to run `sdlc_commit`
+
+Once all findings have been remediated (or the user chooses to stop early), do NOT auto-commit. Prompt the user with the next pipeline step:
+
+> Ready to commit the remediations? Run the `commit` skill (`sdlc_commit`) to stage and commit the changes; an autosquash rebase against `main` will fold the fixups into their owning commits. Then re-run `sdlc_pr` to update the PR description.
+
+DO NOT proceed on your own.
+
+## Edge Cases
+
+- **Branch checkout fails (uncommitted changes):** Stop and ask the user how to handle the conflict.
+- **Branch checkout fails (missing remote ref):** Stop and report the situation; the supplied branch name may be stale.
+- **Reviewer's intent is ambiguous:** Ask the user to clarify before proposing solutions; do not guess.
+- **Finding is already addressed by an earlier remediation in this session:** Mark the corresponding todo complete with a note (e.g., "obviated by remediation of finding #1") and move on.
+- **Finding has been resolved in GitHub between the server query and the verification re-query:** Drop the finding from the working set with a note.
+- **No file owns the touched surface (entirely new code):** A net-new commit is appropriate. Emit `git commit -m "<subject>"` instead of a fixup, with a recommended subject in the conventional-commit style.

--- a/src/sdlc/skills/implement.md
+++ b/src/sdlc/skills/implement.md
@@ -1,11 +1,11 @@
 ---
 name: implement
 description: >
-  Implement a GitHub issue. Use this skill whenever the user says "implement",
-  "implement #N", "start implementing #N", or similar. Accepts an issue number,
-  fetches the issue, creates a branch, gathers context, and enters planning
-  phase to design a concrete execution plan before writing code. On
-  re-invocation after a PR exists, addresses unresolved review feedback.
+  Begin a fresh implementation of a GitHub issue. Invoked by the
+  `sdlc_implement` MCP endpoint when the supplied number is an issue with
+  no linked PR. Fetches the issue, creates a branch, gathers codebase
+  context, and enters planning phase to design a concrete execution plan
+  before writing any code.
 subagent:
   support: optional
   type: general-purpose
@@ -19,11 +19,11 @@ The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RE
 
 # Implement Skill
 
-Fetch a GitHub issue, create a branch, gather codebase context, and enter planning phase to design a concrete execution plan before writing any code. On re-invocation when a PR already exists, address unresolved review feedback or verify implementation completeness.
+Fetch a GitHub issue, create a branch, gather codebase context, and enter planning phase to design a concrete execution plan before writing any code. The MCP endpoint routes PR-based work to sibling skills (`implement-continue`, `implement-feedback`); this skill covers the fresh-start path only.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **second** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine the implementation.
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **second** stage. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when the supplied number is an issue with no linked PR. PR-based work (continuing an in-progress branch or addressing review feedback) is routed to the `implement-continue` and `implement-feedback` skills respectively.
 
 ## Implementation Notes
 
@@ -44,13 +44,12 @@ This skill is part of the development workflow pipeline: `issue` → `implement`
 
 - MUST enter planning phase and receive user approval before writing any code.
 - MUST NOT create or modify files outside the scope of the approved plan.
-- MUST check for an existing PR and address unresolved review comments on re-invocation before planning new work.
 - MUST NOT proceed to the next pipeline step autonomously -- always prompt the user.
 - MUST use the `understand-chat` skill to query the knowledge graph for context gathering when `.understand-anything/knowledge-graph.json` exists.
 
 ## Arguments
 
-An issue number MUST be provided as the sole argument (e.g., `implement` with issue #103).
+An issue number MUST be provided as the sole argument (e.g., `implement` with issue #103). The MCP endpoint routes PR numbers to sibling skills; if this skill is reached, the supplied number is an issue with no linked PR.
 
 ## Subagent Execution (Optional)
 
@@ -75,13 +74,12 @@ This skill MAY be executed in an isolated subagent to preserve parent context. W
 
 1. Resolve target repository
 2. Fetch the issue
-3. Check for existing PR (re-invocation path)
-4. Generate branch name and create branch
-5. Assign the issue
-6. Gather context
-7. Enter planning phase
-8. Execute after approval
-9. Prompt the user to move onto the test or commit step
+3. Generate branch name and create branch
+4. Assign the issue
+5. Gather context
+6. Enter planning phase
+7. Execute after approval
+8. Prompt the user to move onto the test or commit step
 
 ### 1. Resolve target repository
 
@@ -103,38 +101,7 @@ gh issue view <number> --repo <target>
 
 Read the issue title, body, and labels. If the issue does not exist or is closed, inform the user and stop. The `--repo <target>` flag ensures the issue is fetched from the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
 
-### 3. Check for existing PR (re-invocation path)
-
-Query for a linked PR:
-
-```bash
-gh pr list --repo <target> --search "Closes #<number>" --json number,headRefName,url --jq '.[0]'
-```
-
-- **If a PR exists** — check out the branch (`git fetch origin <branch> && git checkout <branch>`). Then check for unresolved review comments:
-
-  ```bash
-  gh api graphql -f query='
-    query($owner: String!, $repo: String!, $pr: Int!) {
-      repository(owner: $owner, name: $repo) {
-        pullRequest(number: $pr) {
-          reviewThreads(first: 100) {
-            nodes { isResolved comments(first: 1) { nodes { body path line } } }
-          }
-        }
-      }
-    }
-  ' -f owner='<owner>' -f repo='<repo>' -F pr=<number>
-  ```
-
-  **Definition of "unresolved review comment":** A review comment is unresolved when its thread is literally marked as unresolved in GitHub's review UI (i.e., the thread has not been clicked "Resolve conversation"). This is a binary GitHub state, not a judgment call. Use the `isResolved` field on review comment threads to determine this. An unresolved thread means the reviewer intentionally left it open — the skill MUST read each unresolved comment, understand what the reviewer is asking for, and plan changes to address it. Do not dismiss unresolved comments as already handled without verifying the reviewer's intent.
-
-  - **If unresolved comments exist** — read each comment, understand the feedback, and proceed to step 6 (gather context) then step 7 (plan changes to address the feedback).
-  - **If no unresolved comments** — verify that the issue is fully implemented: review the issue body against the current branch state and tie off any loose ends. If everything is complete, inform the user and stop. Otherwise, plan remaining work.
-
-- **If no PR exists** — this is a fresh implementation. Continue to step 4.
-
-### 4. Generate branch name and create branch
+### 3. Generate branch name and create branch
 
 Derive a short, descriptive branch name from the issue number and title:
 
@@ -154,7 +121,7 @@ git checkout -b <branch-name> main
 
 If the branch already exists, the user MUST be asked whether to switch to it or recreate it.
 
-### 5. Assign the issue
+### 4. Assign the issue
 
 Assign the issue to the current user so that ownership is visible on the board:
 
@@ -164,7 +131,7 @@ gh issue edit <number> --repo <target> --add-assignee @me
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
 
-### 6. Gather context
+### 5. Gather context
 
 Before entering planning phase, MUST read enough of the codebase to plan confidently:
 
@@ -174,20 +141,20 @@ Before entering planning phase, MUST read enough of the codebase to plan confide
 - MUST resolve applicable test guides by calling `sdlc_guides_for` with the candidate or referenced source-file paths and `kind="test"`, then read every returned URI to internalize the relevant testing conventions.
 - MUST read project-level instructions (`AGENTS.md`) for build tooling, documentation style, and architecture context.
 
-### 7. Enter planning phase
+### 6. Enter planning phase
 
 The execution plan must be presented to the user for approval. It:
 
-- MUST map the issue's requirements (or unresolved review comments, on re-invocation) to concrete code changes: exact files, functions, classes, and the nature of each modification.
+- MUST map the issue's requirements to concrete code changes: exact files, functions, classes, and the nature of each modification.
 - SHOULD prefer test-first ordering when applicable.
 - MUST follow the testing conventions in the test guides resolved via `sdlc_guides_for` (kind=`test`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
 - MUST include a verification section with the exact command(s) to run the test suite (see the project test guide for the runner command).
 
-### 8. Execute after approval
+### 7. Execute after approval
 
 Once the user approves the plan, implement each step sequentially.
 
-### 9. Prompt the user to move onto the test or commit step
+### 8. Prompt the user to move onto the test or commit step
 
 The user MUST be prompted with the next pipeline step: "Ready to generate tests? Run the `test` skill with the issue number to analyze coverage and write tests. Or ready to commit? Run the `commit` skill to stage and commit the changes." DO NOT proceed on your own.
 
@@ -196,4 +163,3 @@ The user MUST be prompted with the next pipeline step: "Ready to generate tests?
 - **Branch already exists:** Ask the user whether to switch to it or recreate it.
 - **Issue is closed:** Inform the user and stop.
 - **Merge conflicts:** Stop and explain the situation rather than trying to resolve automatically.
-- **Re-invocation with PR but no unresolved comments:** Verify the issue is fully implemented. If complete, inform the user and stop.

--- a/tests/test_pr_state.py
+++ b/tests/test_pr_state.py
@@ -1,0 +1,436 @@
+"""Tests for sdlc.pr_state — gh wrappers and PR-state dispatch."""
+
+import json
+
+import pytest
+
+from sdlc import pr_state
+from sdlc.pr_state import Finding, Findings, GhUnavailable, PrContext
+
+
+def _make_fake_run_gh(responses):
+    """Build a fake _run_gh that maps argument tuples to canned outputs.
+
+    Each ``responses`` entry maps a tuple of gh args to one of:
+      * a string — returned as the canned stdout.
+      * ``None`` — simulates a failing gh command (returns ``None`` to
+        callers that pass ``allow_failure=True``; otherwise raises
+        ``GhUnavailable``).
+      * an ``Exception`` instance — raised directly, regardless of
+        ``allow_failure``.
+    """
+
+    def fake(args, allow_failure=False):
+        key = tuple(args)
+        if key not in responses:
+            raise AssertionError(f"unexpected gh call: {args}")
+        response = responses[key]
+        if isinstance(response, Exception):
+            raise response
+        if response is None:
+            if allow_failure:
+                return None
+            raise GhUnavailable(f"gh {' '.join(args)} failed (canned)")
+        return response
+
+    return fake
+
+
+_REPO_VIEW_FIELDS = "owner,name,isFork,parent"
+_REPO_NOT_FORK = json.dumps(
+    {
+        "owner": {"login": "conradbzura"},
+        "name": "sdlc",
+        "isFork": False,
+        "parent": None,
+    }
+)
+_REPO_FORK = json.dumps(
+    {
+        "owner": {"login": "fork-owner"},
+        "name": "sdlc",
+        "isFork": True,
+        "parent": {"owner": {"login": "upstream"}, "name": "sdlc"},
+    }
+)
+_PR_VIEW_42 = json.dumps(
+    {"number": 42, "headRefName": "feature-x", "url": "https://example/pr/42"}
+)
+_GRAPHQL_QUERY = (
+    "query=query($owner: String!, $repo: String!, $pr: Int!) "
+    "{ repository(owner: $owner, name: $repo) { pullRequest(number: $pr) "
+    "{ reviewThreads(first: 100) { nodes { isResolved comments(first: 1) "
+    "{ nodes { body path line author { login } } } } } } } }"
+)
+
+
+def _graphql_payload(threads):
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {"nodes": threads}
+                    }
+                }
+            }
+        }
+    )
+
+
+def _reviews_payload(reviews):
+    return json.dumps({"reviews": reviews})
+
+
+def _graphql_args(owner, repo, pr_number):
+    return (
+        "api", "graphql",
+        "-f", _GRAPHQL_QUERY,
+        "-f", f"owner={owner}",
+        "-f", f"repo={repo}",
+        "-F", f"pr={pr_number}",
+    )
+
+
+def test_dispatch_with_issue_and_no_linked_pr(monkeypatch):
+    """Test dispatch returns None for a fresh issue with no linked PR.
+
+    Given:
+        Number 99 classifies as an issue and no PR closes it.
+    When:
+        dispatch(99) is called.
+    Then:
+        It should return None to signal the fresh-implementation flow.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "99", "--json", "number,headRefName,url"): None,
+        ("issue", "view", "99"): "issue body",
+        (
+            "pr", "list", "--search", "Closes #99",
+            "--json", "number,headRefName,url", "--jq", ".[0]",
+        ): "null\n",
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(99)
+
+    # Assert
+    assert result is None
+
+
+def test_dispatch_with_issue_linked_pr_and_no_feedback(monkeypatch):
+    """Test dispatch returns a PrContext when the linked PR has no feedback.
+
+    Given:
+        An issue number whose linked PR has zero unresolved review threads
+        and zero non-empty review-body comments.
+    When:
+        dispatch(99) is called.
+    Then:
+        It should return a PrContext carrying the PR's metadata.
+    """
+    # Arrange
+    pr_meta = {
+        "number": 42,
+        "headRefName": "feature-x",
+        "url": "https://example/pr/42",
+    }
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "99", "--json", "number,headRefName,url"): None,
+        ("issue", "view", "99"): "issue body",
+        (
+            "pr", "list", "--search", "Closes #99",
+            "--json", "number,headRefName,url", "--jq", ".[0]",
+        ): json.dumps(pr_meta),
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(99)
+
+    # Assert
+    assert result == PrContext(
+        pr_number=42, head_ref="feature-x", url="https://example/pr/42"
+    )
+
+
+def test_dispatch_with_pr_number_and_no_feedback(monkeypatch):
+    """Test dispatch returns a PrContext when a PR number is passed directly.
+
+    Given:
+        Number 42 classifies as a PR with zero unresolved feedback.
+    When:
+        dispatch(42) is called.
+    Then:
+        It should return a PrContext carrying the PR's own metadata, with
+        no detour through find_linked_pr.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(42)
+
+    # Assert
+    assert result == PrContext(
+        pr_number=42, head_ref="feature-x", url="https://example/pr/42"
+    )
+
+
+def test_dispatch_with_unresolved_threads(monkeypatch):
+    """Test dispatch returns Findings when a PR has unresolved review threads.
+
+    Given:
+        A PR with one unresolved and one resolved thread.
+    When:
+        dispatch(42) is called.
+    Then:
+        It should return Findings containing only the unresolved thread.
+    """
+    # Arrange
+    threads = [
+        {
+            "isResolved": False,
+            "comments": {"nodes": [{
+                "body": "rename foo to bar",
+                "path": "src/sdlc/server.py",
+                "line": 64,
+                "author": {"login": "alice"},
+            }]},
+        },
+        {
+            "isResolved": True,
+            "comments": {"nodes": [{
+                "body": "ignore me — already fixed",
+                "path": "src/sdlc/guides.py",
+                "line": 10,
+                "author": {"login": "bob"},
+            }]},
+        },
+    ]
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload(threads),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(42)
+
+    # Assert
+    assert isinstance(result, Findings)
+    assert result.pr_number == 42
+    assert result.head_ref == "feature-x"
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.kind == "review_thread"
+    assert finding.path == "src/sdlc/server.py"
+    assert finding.line == 64
+    assert "rename foo to bar" in finding.body
+    assert finding.author == "alice"
+
+
+def test_dispatch_with_review_body_comments(monkeypatch):
+    """Test dispatch surfaces non-empty review-body comments alongside threads.
+
+    Given:
+        A PR with no unresolved threads but one non-empty review body and
+        one empty review body (an APPROVED-only review).
+    When:
+        dispatch(42) is called.
+    Then:
+        It should return Findings containing only the non-empty review-body
+        comment marked with kind="review_body" and no file/line.
+    """
+    # Arrange
+    reviews = [
+        {
+            "author": {"login": "alice"},
+            "body": "Please address the doc gap.",
+            "state": "COMMENTED",
+        },
+        {"author": {"login": "bob"}, "body": "", "state": "APPROVED"},
+    ]
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload(reviews),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(42)
+
+    # Assert
+    assert isinstance(result, Findings)
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.kind == "review_body"
+    assert finding.path is None
+    assert finding.line is None
+    assert "Please address the doc gap." in finding.body
+    assert finding.author == "alice"
+
+
+def test_dispatch_with_unknown_number(monkeypatch):
+    """Test dispatch raises when the number does not name an issue or PR.
+
+    Given:
+        Number 999 fails both the pr-view and issue-view probes.
+    When:
+        dispatch(999) is called.
+    Then:
+        It should raise GhUnavailable.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "999", "--json", "number,headRefName,url"): None,
+        ("issue", "view", "999"): None,
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act & assert
+    with pytest.raises(GhUnavailable):
+        pr_state.dispatch(999)
+
+
+def test_dispatch_when_repo_view_fails(monkeypatch):
+    """Test dispatch raises GhUnavailable when gh repo view fails.
+
+    Given:
+        gh repo view returns a non-zero exit (e.g., gh missing or unauth).
+    When:
+        dispatch(42) is called.
+    Then:
+        It should raise GhUnavailable.
+    """
+    # Arrange
+    def fake(args, allow_failure=False):
+        raise GhUnavailable("gh repo view failed (canned)")
+
+    monkeypatch.setattr(pr_state, "_run_gh", fake)
+
+    # Act & assert
+    with pytest.raises(GhUnavailable):
+        pr_state.dispatch(42)
+
+
+def test_dispatch_with_fork_repo(monkeypatch):
+    """Test dispatch routes gh calls to upstream when current repo is a fork.
+
+    Given:
+        gh repo view reports the repo is a fork of upstream/sdlc.
+    When:
+        dispatch(42) is called.
+    Then:
+        Subsequent gh commands should include --repo upstream/sdlc and the
+        graphql variables should reference the upstream owner/repo.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_FORK,
+        (
+            "pr", "view", "42", "--repo", "upstream/sdlc",
+            "--json", "number,headRefName,url",
+        ): _PR_VIEW_42,
+        _graphql_args("upstream", "sdlc", 42): _graphql_payload([]),
+        (
+            "pr", "view", "42", "--repo", "upstream/sdlc", "--json", "reviews",
+        ): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.dispatch(42)
+
+    # Assert
+    assert isinstance(result, PrContext)
+    assert result.pr_number == 42
+
+
+class TestFindings:
+    def test_format_with_thread_finding(self):
+        """Test Findings.format renders thread findings with file:line citations.
+
+        Given:
+            Findings holding one review_thread finding.
+        When:
+            format() is called.
+        Then:
+            The output should include file:line, body, and author.
+        """
+        # Arrange
+        findings = Findings(
+            pr_number=42,
+            head_ref="feature-x",
+            url="https://example/pr/42",
+            findings=[
+                Finding(
+                    kind="review_thread",
+                    path="src/sdlc/server.py",
+                    line=64,
+                    body="rename foo to bar",
+                    author="alice",
+                ),
+            ],
+        )
+
+        # Act
+        rendered = findings.format()
+
+        # Assert
+        assert "src/sdlc/server.py:64" in rendered
+        assert "rename foo to bar" in rendered
+        assert "alice" in rendered
+
+    def test_format_with_review_body_finding(self):
+        """Test Findings.format renders review-body comments without file/line.
+
+        Given:
+            Findings holding one review_body finding (PR-level comment).
+        When:
+            format() is called.
+        Then:
+            The output should include the body and author and MUST NOT include
+            a None file/line citation.
+        """
+        # Arrange
+        findings = Findings(
+            pr_number=42,
+            head_ref="feature-x",
+            url="https://example/pr/42",
+            findings=[
+                Finding(
+                    kind="review_body",
+                    path=None,
+                    line=None,
+                    body="Please address the doc gap.",
+                    author="alice",
+                ),
+            ],
+        )
+
+        # Act
+        rendered = findings.format()
+
+        # Assert
+        assert "Please address the doc gap." in rendered
+        assert "alice" in rendered
+        assert "None:None" not in rendered
+        assert ":None" not in rendered

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,6 +4,8 @@ import json
 
 import pytest
 
+from sdlc import pr_state
+from sdlc.pr_state import Finding, Findings, GhUnavailable, PrContext
 from sdlc.server import (
     agents_md,
     get_default_config,
@@ -60,22 +62,114 @@ async def test_sdlc_issue_should_append_context_when_provided():
 
 
 @pytest.mark.asyncio
-async def test_sdlc_implement_should_interpolate_issue_number():
-    """Test sdlc_implement returns skill content with interpolated issue number.
+async def test_sdlc_implement_with_no_pr(monkeypatch):
+    """Test sdlc_implement returns the fresh skill when no PR is linked.
 
     Given:
-        An issue number.
+        pr_state.dispatch returns None for the given number.
     When:
-        sdlc_implement(issue_number=42) is called.
+        sdlc_implement(number=42) is called.
     Then:
-        It should return implement skill content with #42 appended.
+        It should return the fresh implement skill with #42 appended.
     """
+    # Arrange
+    monkeypatch.setattr(pr_state, "dispatch", lambda number: None)
+
     # Act
-    result = await sdlc_implement(issue_number=42)
+    result = await sdlc_implement(number=42)
 
     # Assert
     assert "# Implement Skill" in result
+    assert "# Implement Continue Skill" not in result
+    assert "# Implement Feedback Skill" not in result
     assert "#42" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_with_no_feedback_pr(monkeypatch):
+    """Test sdlc_implement returns the continue skill for a PR with no feedback.
+
+    Given:
+        pr_state.dispatch returns a PrContext for the given number.
+    When:
+        sdlc_implement(number=42) is called.
+    Then:
+        It should return the continue skill with the PR metadata appended.
+    """
+    # Arrange
+    context = PrContext(pr_number=42, head_ref="feature-x", url="https://example/pr/42")
+    monkeypatch.setattr(pr_state, "dispatch", lambda number: context)
+
+    # Act
+    result = await sdlc_implement(number=42)
+
+    # Assert
+    assert "# Implement Continue Skill" in result
+    assert "feature-x" in result
+    assert "https://example/pr/42" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_with_findings(monkeypatch):
+    """Test sdlc_implement returns the feedback skill when findings exist.
+
+    Given:
+        pr_state.dispatch returns a Findings instance for the given number.
+    When:
+        sdlc_implement(number=42) is called.
+    Then:
+        It should return the feedback skill with formatted findings appended.
+    """
+    # Arrange
+    findings = Findings(
+        pr_number=42,
+        head_ref="feature-x",
+        url="https://example/pr/42",
+        findings=[
+            Finding(
+                kind="review_thread",
+                path="src/sdlc/server.py",
+                line=64,
+                body="rename foo to bar",
+                author="alice",
+            ),
+        ],
+    )
+    monkeypatch.setattr(pr_state, "dispatch", lambda number: findings)
+
+    # Act
+    result = await sdlc_implement(number=42)
+
+    # Assert
+    assert "# Implement Feedback Skill" in result
+    assert "src/sdlc/server.py:64" in result
+    assert "rename foo to bar" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_when_gh_unavailable(monkeypatch):
+    """Test sdlc_implement falls back to the fresh skill when gh is unavailable.
+
+    Given:
+        pr_state.dispatch raises GhUnavailable.
+    When:
+        sdlc_implement(number=42) is called.
+    Then:
+        It should return the fresh skill with a diagnostic comment appended.
+    """
+    # Arrange
+    def raise_unavailable(_number):
+        raise GhUnavailable("gh executable not found on PATH")
+
+    monkeypatch.setattr(pr_state, "dispatch", raise_unavailable)
+
+    # Act
+    result = await sdlc_implement(number=42)
+
+    # Assert
+    assert "# Implement Skill" in result
+    assert "diagnostic" in result
+    assert "gh executable not found" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Move PR-state detection from the LLM into the `sdlc_implement` MCP endpoint so a single call routes to one of three focused skill prompts based on what GitHub already knows. The endpoint accepts either an issue number or a PR number under a single positional argument and uses a new `pr_state` helper module that wraps the `gh` CLI to classify the number, look up linked PRs, and enumerate unresolved review threads alongside non-empty review-body comments. The previous `implement.md` re-invocation branch is split into two new sibling skills: `implement-continue.md` for an in-progress PR with no feedback yet, and `implement-feedback.md` encoding a structured six-point macro for PR review feedback remediation.

Closes #11

## Proposed changes

### `pr_state` helper module
Wrap `gh` in `_run_gh` with explicit error handling (raise on missing binary or unexpected failure, return `None` on non-zero exits when the caller opts in). Resolve target repo via `gh repo view --json owner,name,isFork,parent`, including upstream redirection when on a fork. Classify a number as PR / issue / missing by probing `gh pr view` first (succeeds only for PRs) then falling back to `gh issue view`. Look up the PR linked to an issue via `gh pr list --search "Closes #<n>"`. Enumerate unresolved review threads via GraphQL and non-empty review-body comments via `gh pr view --json reviews`. Public `dispatch(number)` returns `None`, a `PrContext`, or a `Findings` instance to drive the server's three-way dispatch; all error paths surface a single `GhUnavailable` exception.

### Server dispatch
Rewrite `sdlc_implement` to accept `number: int` and call `pr_state.dispatch`. Return the fresh `implement` prompt for `None`, the new `implement-continue` prompt for a `PrContext`, and the new `implement-feedback` prompt with formatted findings appended for a `Findings`. On `GhUnavailable`, return the fresh prompt suffixed with an HTML-comment diagnostic so the LLM can proceed manually without the dispatch silently swallowing the failure.

### Skill split
Trim `implement.md` to the fresh-start flow only; drop the re-invocation branch and renumber remaining steps. Add `implement-continue.md` for picking up an in-progress PR with no feedback — checks out the PR branch, identifies the linked issue via GitHub's `closingIssuesReferences` GraphQL connection (falling back to parsing the PR body), diffs the current branch state against the issue's expected outcome, and plans only the remaining work. Add `implement-feedback.md` encoding the six-point macro: gather all findings (re-querying both review threads and review-body comments), order by canonical severity (correctness → code quality → integration tests → unit tests → style → docs), track as a todo list, present sequentially with per-finding `file:line` citation / evaluation / options / approval gate, do not auto-commit, emit ready-to-paste `git commit --fixup=<sha>` blocks mapping each touched file back to its owning commit on the branch.

### Documentation
Add the `pr_state` module and the two new skill files to the directory layouts in `AGENTS.md` and `README.md`. Reword the `sdlc_implement` row in the MCP Tools tables to describe all three flows. Add a sentence to `AGENTS.md` noting that the dispatch is server-side and that the LLM never has to branch on PR state.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_pr_state` | Repo is not a fork and #99 is an issue with no linked PR | `dispatch(99)` is called | Returns `None` | Fresh-flow signaling |
| 2 | `test_pr_state` | Issue #99 has a linked PR with no unresolved feedback | `dispatch(99)` is called | Returns a `PrContext` with the PR metadata | Continue-flow signaling |
| 3 | `test_pr_state` | A PR number is passed directly with no feedback | `dispatch(42)` is called | Returns a `PrContext` without going through `find_linked_pr` | Direct PR-number path |
| 4 | `test_pr_state` | PR has one unresolved and one resolved review thread | `dispatch(42)` is called | Returns `Findings` containing only the unresolved thread | Thread filtering |
| 5 | `test_pr_state` | PR has one non-empty and one empty review-body comment | `dispatch(42)` is called | Returns `Findings` containing only the non-empty review body | Review-body filtering |
| 6 | `test_pr_state` | A number that is neither an issue nor a PR | `dispatch(999)` is called | Raises `GhUnavailable` | Missing-number error path |
| 7 | `test_pr_state` | `gh repo view` fails (gh missing or unauth) | `dispatch(42)` is called | Raises `GhUnavailable` | gh-unavailable propagation |
| 8 | `test_pr_state` | The current repo is a fork of `upstream/sdlc` | `dispatch(42)` is called | All gh calls include `--repo upstream/sdlc` and the GraphQL vars target `upstream/sdlc` | Fork-aware routing |
| 9 | `test_pr_state` | A `Findings` with a `review_thread` finding | `format()` is called | Output includes `file:line`, body, and author | Thread rendering |
| 10 | `test_pr_state` | A `Findings` with a `review_body` finding (no path/line) | `format()` is called | Output includes body and author and omits any `:None` placeholder | Review-body rendering |
| 11 | `test_server` | `pr_state.dispatch` returns `None` | `sdlc_implement(number=42)` is called | Returns the fresh `# Implement Skill` content with `#42` appended | Fresh-skill path |
| 12 | `test_server` | `pr_state.dispatch` returns a `PrContext` | `sdlc_implement(number=42)` is called | Returns the `# Implement Continue Skill` content with PR metadata appended | Continue-skill path |
| 13 | `test_server` | `pr_state.dispatch` returns a `Findings` | `sdlc_implement(number=42)` is called | Returns the `# Implement Feedback Skill` content with formatted findings appended | Feedback-skill path |
| 14 | `test_server` | `pr_state.dispatch` raises `GhUnavailable` | `sdlc_implement(number=42)` is called | Returns the fresh skill content suffixed with a diagnostic HTML comment | gh-failure fallback |