### PR TITLE
Fix pr skill merge-base fallback hardcoding "main" — Closes #4

### DIFF
--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -40,6 +40,20 @@ def _read_file(path: Path) -> str:
     return path.read_text()
 
 
+def _target_branch_directive(target: str) -> str:
+    """Render the target-branch-override directive for a resolved target.
+
+    The wording is byte-identical across `sdlc_implement` and `sdlc_pr` so the
+    skills can reference it uniformly: implement branches FROM this branch and
+    pr bases the PR AGAINST it, instead of the resolved default branch.
+    """
+    return (
+        f"Target branch override: {target}\n"
+        "Branch from / base against this branch instead of the resolved "
+        "default branch."
+    )
+
+
 @mcp.tool()
 async def sdlc_issue(context: str | None = None) -> str:
     """Draft and push a GitHub issue.
@@ -59,7 +73,7 @@ async def sdlc_issue(context: str | None = None) -> str:
 
 
 @mcp.tool()
-async def sdlc_implement(number: int) -> str:
+async def sdlc_implement(number: int, target: str | None = None) -> str:
     """Implement a GitHub issue or address feedback on an open PR.
 
     Use when the user says "implement", "implement #N", or similar.
@@ -74,19 +88,29 @@ async def sdlc_implement(number: int) -> str:
 
     Args:
         number: An issue number or an open PR number.
+        target: Optional branch to override the resolved default. When set,
+            a fresh implementation creates its branch from this branch instead
+            of the repo default. Ignored on the continue and feedback paths,
+            which operate on an existing branch.
     """
     try:
         state = pr_state.dispatch(number)
     except pr_state.GhUnavailable as exc:
         skill = _read_skill("implement")
-        return (
+        parts = [
             f"{skill}\n---\n\nTarget: #{number}\n\n"
             f"<!-- diagnostic: PR state could not be determined ({exc}); "
             "falling back to fresh-implementation prompt. -->"
-        )
+        ]
+        if target:
+            parts.append(f"\n{_target_branch_directive(target)}")
+        return "".join(parts)
     if state is None:
         skill = _read_skill("implement")
-        return f"{skill}\n---\n\nTarget issue: #{number}"
+        parts = [f"{skill}\n---\n\nTarget issue: #{number}"]
+        if target:
+            parts.append(f"\n{_target_branch_directive(target)}")
+        return "".join(parts)
     if isinstance(state, pr_state.Findings):
         skill = _read_skill("implement-feedback")
         return f"{skill}\n---\n\nTarget: #{number}\n{state.format()}"
@@ -125,7 +149,7 @@ async def sdlc_commit() -> str:
 
 
 @mcp.tool()
-async def sdlc_pr(issue_number: int) -> str:
+async def sdlc_pr(issue_number: int, target: str | None = None) -> str:
     """Review changes and create a draft pull request.
 
     Use when the user says "pr", "create a PR for #N", "open a PR",
@@ -134,9 +158,14 @@ async def sdlc_pr(issue_number: int) -> str:
 
     Args:
         issue_number: The GitHub issue number to create a PR for.
+        target: Optional branch to override the resolved default. When set,
+            the PR is based against this branch instead of the repo default.
     """
     skill = _read_skill("pr")
-    return f"{skill}\n---\n\nTarget issue: #{issue_number}"
+    parts = [f"{skill}\n---\n\nTarget issue: #{issue_number}"]
+    if target:
+        parts.append(f"\n{_target_branch_directive(target)}")
+    return "".join(parts)
 
 
 @mcp.tool()

--- a/src/sdlc/skills/implement.md
+++ b/src/sdlc/skills/implement.md
@@ -49,7 +49,9 @@ This skill is part of the development workflow pipeline: `issue` → `implement`
 
 ## Arguments
 
-An issue number MUST be provided as the sole argument (e.g., `implement` with issue #103). The MCP endpoint routes PR numbers to sibling skills; if this skill is reached, the supplied number is an issue with no linked PR.
+An issue number MUST be provided (e.g., `implement` with issue #103). The MCP endpoint routes PR numbers to sibling skills; if this skill is reached, the supplied number is an issue with no linked PR.
+
+An optional `target` branch MAY be provided to override the branch the new branch is created from. When set, the tool output carries a `Target branch override: <target>` directive and the new branch MUST be created from `<target>` instead of the resolved repo default (see step 4).
 
 ## Subagent Execution (Optional)
 
@@ -115,8 +117,19 @@ Examples:
 
 The branch name MUST be under 50 characters. Filler words SHOULD be stripped.
 
+Resolve the branch to create from before checking out. Precedence:
+
+1. **Target branch override** — when a `Target branch override: <target>` directive is present in the tool output, the new branch MUST be created from `<target>`.
+2. **Repo default** — otherwise the new branch MUST be created from the repository's default branch, resolved dynamically:
+
+   ```bash
+   gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
+   ```
+
+There is no literal `main` fallback — the default branch MUST always be resolved via `gh`.
+
 ```bash
-git checkout -b <branch-name> main
+git checkout -b <branch-name> <resolved-base>
 ```
 
 If the branch already exists, the user MUST be asked whether to switch to it or recreate it.

--- a/src/sdlc/skills/pr.md
+++ b/src/sdlc/skills/pr.md
@@ -29,7 +29,7 @@ This skill is part of the development workflow pipeline: `issue` → `implement`
 - MUST always create the PR as a draft -- never mark it ready for review automatically.
 - MUST NOT create the PR until the user explicitly approves the description.
 - MUST match the PR title exactly to the issue title with ` — Closes #<number>` appended.
-- MUST describe the net `<base>..HEAD` diff in the PR body, where `<base>` is the PR's base branch (discoverable via `gh pr view <number> --json baseRefName`), not the sequence of changes across the PR's commits. If a file, block, or behavior was added and later removed within the same PR (e.g., via fixup rebase or interactive history rewriting), it MUST NOT appear in the description — from the base branch's perspective it never existed.
+- MUST describe the net `<base>..HEAD` diff in the PR body, where `<base>` is the resolved base branch, not the sequence of changes across the PR's commits. `<base>` is resolved by precedence (see step 3): a `Target branch override: <target>` directive when present, otherwise the existing PR's base branch (`gh pr view <number> --json baseRefName`) when a PR exists, otherwise the repo default branch resolved via `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. There is no literal `main` fallback. If a file, block, or behavior was added and later removed within the same PR (e.g., via fixup rebase or interactive history rewriting), it MUST NOT appear in the description — from the base branch's perspective it never existed.
 - MUST use a heredoc for the `gh pr create` body to avoid shell escaping issues.
 - MUST structure the PR description according to the project's PR template if one exists, otherwise the built-in format defined in this document.
 - MUST assign the PR to the current user upon creation via `gh pr edit <number> --add-assignee @me`.
@@ -37,7 +37,9 @@ This skill is part of the development workflow pipeline: `issue` → `implement`
 
 ## Arguments
 
-An issue number MUST be provided as the sole argument (e.g., `pr` with issue #103). The issue number is used to identify the branch (`<number>-<kebab-case-summary>`) and to link the PR via `Closes #<number>`.
+An issue number MUST be provided (e.g., `pr` with issue #103). The issue number is used to identify the branch (`<number>-<kebab-case-summary>`) and to link the PR via `Closes #<number>`.
+
+An optional `target` branch MAY be provided to override the PR base. When set, the tool output carries a `Target branch override: <target>` directive and the PR MUST be based against `<target>` instead of the existing PR base or resolved repo default (see step 3 and step 7).
 
 ## Subagent Execution (Optional)
 
@@ -110,10 +112,27 @@ If a PR already exists, this is an update — the description will be edited rat
 
 ### 3. Review the branch diff
 
-Determine the base and diff against it:
+Resolve the base branch `<base>` before diffing. Precedence:
+
+1. **Target branch override** — when a `Target branch override: <target>` directive is present in the tool output, `<base>` MUST be `<target>`.
+2. **Existing PR base** — otherwise, when a PR already exists (detected in step 2), `<base>` MUST be that PR's base branch:
+
+   ```bash
+   gh pr view <number> --repo <target-repo> --json baseRefName --jq .baseRefName
+   ```
+
+3. **Repo default** — otherwise `<base>` MUST be the repository's default branch, resolved dynamically:
+
+   ```bash
+   gh repo view --json defaultBranchRef --jq .defaultBranchRef.name
+   ```
+
+There is no literal `main` fallback — the base MUST always resolve to an override, an existing PR base, or the `gh`-resolved default branch.
+
+Then diff against the resolved base:
 
 ```bash
-git merge-base HEAD $(git rev-parse --abbrev-ref @{upstream} 2>/dev/null || echo main)
+git merge-base HEAD <base>
 git log <merge-base>..HEAD --oneline
 git diff <merge-base>..HEAD
 git diff <merge-base>..HEAD --stat
@@ -186,10 +205,10 @@ git push -u origin <branch-name>
 
 **Creating a new PR:**
 
-A heredoc MUST be used for the body to avoid shell escaping issues:
+A heredoc MUST be used for the body to avoid shell escaping issues. The `--base <base>` flag MUST be passed so the PR targets the same branch the diff was computed against in step 3:
 
 ```bash
-gh pr create --draft --title "<title>" --body "$(cat <<'EOF'
+gh pr create --draft --base <base> --title "<title>" --body "$(cat <<'EOF'
 <body>
 EOF
 )"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -173,6 +173,49 @@ async def test_sdlc_implement_when_gh_unavailable(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_sdlc_implement_should_omit_target_directive_when_no_target(monkeypatch):
+    """Test sdlc_implement omits the override directive when no target is given.
+
+    Given:
+        pr_state.dispatch returns None and no target argument is provided.
+    When:
+        sdlc_implement(number=42) is called.
+    Then:
+        It should return fresh implement skill content without an override directive.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "dispatch", lambda number: None)
+
+    # Act
+    result = await sdlc_implement(number=42)
+
+    # Assert
+    assert "Branch from / base against this branch" not in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_should_append_target_directive_when_target_given(monkeypatch):
+    """Test sdlc_implement appends the override directive when a target is given.
+
+    Given:
+        pr_state.dispatch returns None and a target branch of "stable".
+    When:
+        sdlc_implement(number=42, target="stable") is called.
+    Then:
+        It should return content with the override directive naming "stable".
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "dispatch", lambda number: None)
+
+    # Act
+    result = await sdlc_implement(number=42, target="stable")
+
+    # Assert
+    assert "Target branch override: stable" in result
+    assert "Branch from / base against this branch" in result
+
+
+@pytest.mark.asyncio
 async def test_sdlc_test_should_interpolate_issue_number():
     """Test sdlc_test returns skill content with interpolated issue number.
 
@@ -226,6 +269,43 @@ async def test_sdlc_pr_should_interpolate_issue_number():
     # Assert
     assert "# PR Skill" in result
     assert "#42" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_pr_should_omit_target_directive_when_no_target():
+    """Test sdlc_pr omits the override directive when no target is given.
+
+    Given:
+        No target argument.
+    When:
+        sdlc_pr(issue_number=42) is called.
+    Then:
+        It should return pr skill content without an override directive.
+    """
+    # Act
+    result = await sdlc_pr(issue_number=42)
+
+    # Assert
+    assert "Branch from / base against this branch" not in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_pr_should_append_target_directive_when_target_given():
+    """Test sdlc_pr appends the override directive when a target is given.
+
+    Given:
+        A target branch of "master".
+    When:
+        sdlc_pr(issue_number=42, target="master") is called.
+    Then:
+        It should return content with the override directive naming "master".
+    """
+    # Act
+    result = await sdlc_pr(issue_number=42, target="master")
+
+    # Assert
+    assert "Target branch override: master" in result
+    assert "Branch from / base against this branch" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Replace the hardcoded `main` base-branch assumption in the `implement` and `pr` skills with dynamic resolution, and add an optional `target` parameter to the `sdlc_implement` and `sdlc_pr` tools so work can branch from and target an explicit base branch — for example a hotfix against a `stable` or `master` branch. When `target` is omitted, both skills resolve the repository's default branch via `gh` instead of assuming `main`.

Closes #4

## Proposed changes

### Shared override directive

Add a `_target_branch_directive(target)` helper in `server.py` that renders a single, byte-identical directive reused by both tools, so the skills can match on identical wording. Add an optional `target: str | None = None` parameter to `sdlc_implement` and `sdlc_pr`; when set, append `Target branch override: <target>` to the returned skill text. When omitted, nothing is appended and existing behavior is preserved.

### `implement` skill base resolution

Resolve the branch to create from by precedence: the `target` override directive when present, otherwise the repository default branch via `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`. Remove the literal `main` fallback so `git checkout -b` always uses the resolved base. Document the optional `target` argument.

### `pr` skill base resolution

Resolve `<base>` by three-tier precedence: the `target` override, otherwise the existing PR's base via `gh pr view --json baseRefName`, otherwise the `gh`-resolved repo default. Pass `--base <base>` to `gh pr create` so the PR targets the same branch the diff was computed against. Update the net-diff Invariant and Arguments section accordingly. No literal `main` remains.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_server` | No target argument | `sdlc_implement(issue_number=42)` is called | Returns implement skill content with no override directive | Implement default path |
| 2 | `test_server` | A target branch of `stable` | `sdlc_implement(issue_number=42, target="stable")` is called | Returns the override directive naming `stable` | Implement override |
| 3 | `test_server` | No target argument | `sdlc_pr(issue_number=42)` is called | Returns pr skill content with no override directive | PR default path |
| 4 | `test_server` | A target branch of `master` | `sdlc_pr(issue_number=42, target="master")` is called | Returns the override directive naming `master` | PR override |