### PR TITLE
Support updating existing issues in sdlc_issue — Closes #7

### DIFF
--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -55,18 +55,29 @@ def _target_branch_directive(target: str) -> str:
 
 
 @mcp.tool()
-async def sdlc_issue(context: str | None = None) -> str:
-    """Draft and push a GitHub issue.
+async def sdlc_issue(
+    issue_number: int | None = None, context: str | None = None
+) -> str:
+    """Draft and push a GitHub issue, or update an existing one.
 
     Use when the user says "issue", "file an issue", "create an issue",
     "open a bug report", or similar. If `.issue.md` exists in the repo root,
     it is used as the source. Otherwise the issue is drafted interactively.
+    When an issue number is provided, the existing issue is updated instead of
+    a new one being created.
 
     Args:
+        issue_number: Optional GitHub issue number to update. When omitted, a
+            new issue is drafted; when provided, enter the update workflow.
         context: Optional description of the problem or feature to file.
     """
     skill = _read_skill("issue")
     parts = [skill]
+    if issue_number is not None:
+        parts.append(
+            f"\n---\n\nTarget issue to update: #{issue_number}\n\n"
+            "Enter the update workflow defined in this skill."
+        )
     if context:
         parts.append(f"\n---\n\nUser context for this issue:\n\n{context}")
     return "\n".join(parts)

--- a/src/sdlc/skills/issue.md
+++ b/src/sdlc/skills/issue.md
@@ -18,16 +18,25 @@ The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RE
 
 # Issue Skill
 
-Create a well-structured GitHub issue, either from a prepared `.issue.md` file or interactively from conversation context.
+Create a well-structured GitHub issue, either from a prepared `.issue.md` file or interactively from conversation context, or update an existing issue.
 
 ## Pipeline Context
 
 This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **first** stage. The implement, test, and commit steps are iterative — they can be invoked multiple times for a given issue.
 
+## Arguments
+
+An issue number is OPTIONAL.
+
+- **Absent** — draft and push a **new** issue (the default path). Follow the **Create workflow** below.
+- **Present** (e.g., `issue #42`) — **update** the existing issue with that number. Follow the **Update workflow** below instead of the Create workflow.
+
 ## Invariants
 
 - MUST NOT push the issue to GitHub until the user explicitly approves the draft.
+- MUST NOT edit an existing issue until the user explicitly approves the proposed changes.
 - MUST use a heredoc for the `gh issue create` body to avoid shell escaping issues.
+- MUST use `gh issue edit <n> --body-file` (not an inline `--body`) when updating an existing issue's body.
 - MUST NOT add the `--assignee` flag -- issues are not auto-assigned at creation.
 - MUST use the `understand-chat` skill to query the knowledge graph for context gathering when `.understand-anything/knowledge-graph.json` exists.
 
@@ -48,7 +57,9 @@ This skill MAY be executed in an isolated subagent to preserve parent context. W
 **Other LLM assistants:**
 - Subagent execution may not be supported in your tool. Execute the skill inline following the normal workflow.
 
-## Workflow
+## Create workflow
+
+Follow this workflow when **no issue number** is supplied (the default path).
 
 ### Checklist
 
@@ -269,3 +280,89 @@ The user SHOULD be prompted with the next pipeline step: "Ready to implement? Ru
 ### 10. Prompt the user to move onto the implement step
 
 The user MUST be prompted with the next pipeline step: "Ready to implement? Run the `implement` skill with the issue number to create a branch and start planning." When working from a fork, note that the issue number refers to the issue on the upstream repo. DO NOT proceed on your own.
+
+## Update workflow
+
+Follow this workflow when an **issue number is supplied**. The goal is to apply a targeted edit to an existing issue — not to rewrite it from scratch.
+
+### Checklist
+
+1. Resolve target repository
+2. Fetch the existing issue
+3. Analyze the intended changes
+4. Pre-check labels
+5. Present the diff for approval
+6. Edit the issue
+7. Return the issue URL
+
+### 1. Resolve target repository
+
+Resolve the target repository exactly as in the Create workflow's "Resolve target repository" step: run `gh repo view --json isFork,parent`, and when `isFork` is `true`, use the upstream `<owner>/<name>` as the target unless the user explicitly asks to target the fork. All `gh` commands below that reference the issue or its labels MUST include `--repo <target>` when the target repo differs from the current repo.
+
+### 2. Fetch the existing issue
+
+Fetch the current title, body, and labels:
+
+```bash
+gh issue view <n> --repo <target> --json title,body,labels,state
+```
+
+- **If the issue does not exist** — `gh` exits non-zero. Surface the error to the user and stop; do not attempt to create a new issue.
+- **If the issue is closed** (`state` is `CLOSED`) — do NOT silently edit it. Ask the user whether to reopen it (`gh issue reopen <n> --repo <target>`) before editing, or to refuse the update. Proceed only on the user's explicit instruction.
+
+Record the fetched title, body, and label set as the **current** state — this is the baseline for the diff.
+
+### 3. Analyze the intended changes
+
+Determine the intended changes from the conversational context — what the user asked to add, remove, clarify, or relabel. Compute a **targeted** edit against the current state: change only what the user asked to change. MUST NOT reflow, reword, or restructure untouched prose, and MUST NOT reorder existing sections.
+
+When the current body follows a GitHub form-template structure (the issue was created from a form template in `.github/ISSUE_TEMPLATE/`), the section ordering MUST be preserved and the surrounding sections MUST NOT be reflowed — insert or amend content within the relevant section only.
+
+### 4. Pre-check labels
+
+When the intended changes add or remove labels, the label names MUST be validated against the repository's label set **before** editing, so unknown labels surface early:
+
+```bash
+gh label list --repo <target> --json name --jq '.[].name'
+```
+
+Any label to be added that is not in this set MUST be surfaced to the user before proceeding — do not pass an unknown label to `gh issue edit`. Resolve the discrepancy (correct the name, or ask the user to create the label) before continuing.
+
+### 5. Present the diff for approval
+
+Present the proposed change as a unified diff inside a fenced ` ```diff ` block, showing the current versus proposed **title**, **body**, and **labels**. The diff MUST be targeted — show only the lines that change plus minimal surrounding context, not a full rewrite of the issue:
+
+````markdown
+```diff
+ # <unchanged title line for context>
+@@ Body @@
+-<removed line>
++<added line>
+@@ Labels @@
+-<removed label>
++<added label>
+```
+````
+
+The user MUST explicitly approve the diff before any edit is posted. DO NOT proceed on your own.
+
+### 6. Edit the issue
+
+After approval, post the edit with `gh issue edit`. Write the new body to a temporary file and pass it via `--body-file` so the body is applied verbatim without shell-escaping issues:
+
+```bash
+gh issue edit <n> --repo <target> \
+  --title "<new title>" \
+  --body-file <path> \
+  --add-label "<label>" \
+  --remove-label "<label>"
+```
+
+- Include `--title` only when the title changes.
+- Include `--body-file` only when the body changes; the file MUST contain the full proposed body.
+- Include `--add-label` / `--remove-label` only for labels that actually change. Every `--add-label` value MUST have passed the step-4 pre-check.
+- The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
+
+### 7. Return the issue URL
+
+Print the issue URL returned by `gh issue edit` so the user can review the updated issue directly. If further changes are still needed, the user MAY re-run this skill with the same issue number.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -24,15 +24,15 @@ from sdlc.server import (
 
 
 @pytest.mark.asyncio
-async def test_sdlc_issue_should_return_skill_when_no_context():
+async def test_sdlc_issue_should_return_skill_when_no_arguments():
     """Test sdlc_issue returns skill content when called with no arguments.
 
     Given:
-        No context argument.
+        No issue number and no context argument.
     When:
         sdlc_issue() is called.
     Then:
-        It should return the issue skill content.
+        It should return the issue skill content with no update directive.
     """
     # Act
     result = await sdlc_issue()
@@ -40,6 +40,7 @@ async def test_sdlc_issue_should_return_skill_when_no_context():
     # Assert
     assert "# Issue Skill" in result
     assert "User context" not in result
+    assert "Target issue to update" not in result
 
 
 @pytest.mark.asyncio
@@ -58,6 +59,47 @@ async def test_sdlc_issue_should_append_context_when_provided():
 
     # Assert
     assert "# Issue Skill" in result
+    assert "Add retry logic" in result
+    assert "Target issue to update" not in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_issue_should_append_update_directive_when_issue_number_given():
+    """Test sdlc_issue appends an update directive when an issue number is given.
+
+    Given:
+        An issue number is provided.
+    When:
+        sdlc_issue(issue_number=42) is called.
+    Then:
+        It should return skill content with the update directive and #42.
+    """
+    # Act
+    result = await sdlc_issue(issue_number=42)
+
+    # Assert
+    assert "# Issue Skill" in result
+    assert "Target issue to update: #42" in result
+    assert "User context" not in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_issue_should_append_directive_and_context_when_both_given():
+    """Test sdlc_issue appends both the update directive and the context.
+
+    Given:
+        An issue number and a context string are provided.
+    When:
+        sdlc_issue(issue_number=42, context="Add retry logic") is called.
+    Then:
+        It should return skill content with both the update directive and context.
+    """
+    # Act
+    result = await sdlc_issue(issue_number=42, context="Add retry logic")
+
+    # Assert
+    assert "# Issue Skill" in result
+    assert "Target issue to update: #42" in result
     assert "Add retry logic" in result
 
 


### PR DESCRIPTION
## Summary

Extend `sdlc_issue` to update an existing issue in addition to creating a new one, mirroring how `sdlc_pr` handles an already-linked PR. Add an optional `issue_number` parameter; when provided, the tool appends a directive that routes into a new Update workflow in the issue skill. When omitted, the create path is unchanged.

Closes #7

## Proposed changes

### `sdlc_issue` tool signature

Change the signature to `sdlc_issue(issue_number: int | None = None, context: str | None = None)`. When `issue_number` is provided, append `Target issue to update: #<n>` plus a directive to enter the update workflow. Preserve the existing `context` append behavior unchanged.

### Update workflow in the issue skill

Add an Arguments section (absent → create, present → update) and two Invariants: do not edit before explicit approval, and use `gh issue edit --body-file` for body updates. Wrap the existing steps as the Create workflow and add an Update workflow that resolves the target repo, fetches the issue via `gh issue view --json title,body,labels,state`, computes a targeted edit against the current state, pre-checks labels via `gh label list`, presents a fenced `diff` block for approval, then posts via `gh issue edit` with `--title`/`--body-file`/`--add-label`/`--remove-label`. Document edge cases: nonexistent issue errors out rather than creating, closed issue prompts to reopen or refuse, unknown labels surface before editing, and form-template bodies preserve section ordering without reflow. The create path and the deferred label-suggestion table are left untouched.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_server` | No issue number and no context | `sdlc_issue()` is called | Returns issue skill content with no update directive | Create default path |
| 2 | `test_server` | A context string | `sdlc_issue(context="Add retry logic")` is called | Returns content with the context and no update directive | Context append |
| 3 | `test_server` | An issue number | `sdlc_issue(issue_number=42)` is called | Returns content with the update directive and `#42` | Update directive |
| 4 | `test_server` | An issue number and a context string | `sdlc_issue(issue_number=42, context="Add retry logic")` is called | Returns content with both the update directive and the context | Combined update path |