### PR TITLE
Add a role guide kind with a role template and sdlc_role authoring tool — Closes #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ sdlc/
         │   ├── commit.md
         │   ├── pr.md
         │   ├── review.md
+        │   ├── role.md
         │   └── understand-chat.md
+        ├── role-template.md        # Bundled role-document template
         ├── test-guides/            # Testing conventions (served as MCP resources)
         │   └── python.md
-        └── style-guides/           # Style conventions (served as MCP resources)
-            └── markdown.md
+        ├── style-guides/           # Style conventions (served as MCP resources)
+        │   └── markdown.md
+        └── role-guides/            # Review roles (served as MCP resources)
+            └── general-purpose.md
 ```
 
 ### MCP Tools
@@ -138,6 +142,8 @@ sdlc/
 | `sdlc_pr` | Review changes and create a draft pull request |
 | `sdlc_review` | Review an open pull request for compliance and quality |
 | `sdlc_understand_chat` | Query the codebase knowledge graph |
+| `sdlc_roles` | List the available review roles |
+| `sdlc_role` | Author a review role document |
 
 ### MCP Resources
 
@@ -145,6 +151,8 @@ sdlc/
 |-----|---------|
 | `sdlc://guides/test/python` | Python testing conventions |
 | `sdlc://guides/style/markdown` | Markdown style conventions |
+| `sdlc://guides/role/general-purpose` | Default review role |
+| `sdlc://role-template` | Role-document template |
 | `sdlc://agents-md` | Project-level agent instructions |
 | `sdlc://knowledge-graph` | Codebase knowledge graph (if generated) |
 
@@ -161,6 +169,7 @@ The pipeline enforces disciplined commits — atomic, well-structured, with conv
 - **[src/sdlc/skills/commit.md](./src/sdlc/skills/commit.md)** — Commit skill
 - **[src/sdlc/skills/pr.md](./src/sdlc/skills/pr.md)** — Pull request skill
 - **[src/sdlc/skills/review.md](./src/sdlc/skills/review.md)** — Code review skill
+- **[src/sdlc/skills/role.md](./src/sdlc/skills/role.md)** — Review-role authoring skill
 - **[src/sdlc/test-guides/python.md](./src/sdlc/test-guides/python.md)** — Python testing conventions
 - **[src/sdlc/style-guides/markdown.md](./src/sdlc/style-guides/markdown.md)** — Markdown style conventions
 

--- a/src/sdlc/AGENTS.md
+++ b/src/sdlc/AGENTS.md
@@ -20,6 +20,8 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | `sdlc_review` | 6th | Review an open pull request for compliance and quality |
 | `sdlc_understand_chat` | — | Query the codebase knowledge graph |
 | `sdlc_guides_for` | — | Resolve which test or style guides apply to a list of file paths |
+| `sdlc_roles` | — | List the available review roles as resource URIs |
+| `sdlc_role` | — | Author a review role document (lens, blocking policy, focus globs) |
 
 The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine implementation. `sdlc_implement` accepts either an issue number or a PR number and dispatches between three sibling skill prompts based on PR state: `implement` (fresh start, no PR yet), `implement-continue` (PR exists, no review feedback yet), and `implement-feedback` (PR has unresolved review threads or review-body comments).
 
@@ -29,7 +31,9 @@ The `implement`, `test`, and `commit` tools are iterative — they can be invoke
 |-----|---------|
 | `sdlc://guides/test/{stem}` | Test guide identified by `{stem}` — bundled or user-supplied (e.g. `python`) |
 | `sdlc://guides/style/{stem}` | Style guide identified by `{stem}` — bundled or user-supplied (e.g. `markdown`) |
+| `sdlc://guides/role/{stem}` | Review role identified by `{stem}` — bundled or user-supplied (e.g. `general-purpose`) |
 | `sdlc://config/default` | Package-default `config.json` content (read this to discover the bundled guide-map) |
+| `sdlc://role-template` | Bundled role-document template (the Lens and Blocking policy sections) |
 | `sdlc://agents-md` | This file (project-level agent instructions) |
 | `sdlc://knowledge-graph` | Codebase knowledge graph (if generated) |
 
@@ -37,16 +41,18 @@ Use the `sdlc_guides_for` tool to discover which `{stem}` values apply to a give
 
 ## Project Configuration
 
-Projects can extend or override the bundled test- and style-guides by dropping markdown files under `.sdlc/guides/{test,style}/` and (optionally) declaring a glob-to-guides map in `.sdlc/config.json`. The MCP server merges this user config on top of the package default at startup.
+Projects can extend or override the bundled test-, style-, and role-guides by dropping markdown files under `.sdlc/guides/{test,style,role}/` and (optionally) declaring a glob-to-guides map in `.sdlc/config.json`. The MCP server merges this user config on top of the package default at startup. Review roles use the same `guide-map` mechanism as `test` and `style` guides — a `role` namespace maps globs to role stems — with one difference in how they are consumed: a role is selected explicitly by name, and its `guide-map.role` entries scope which files the selected role's findings apply to (any file may still be read for context).
 
 ### Discovery
 
-Guides are discovered from two sources at startup. Within each `kind` namespace, user guides win on stem collision.
+Guides are discovered from two sources at startup. Within each `kind` namespace (`test`, `style`, `role`), user guides win on stem collision.
 
-1. **Bundled** — `src/sdlc/{test,style}-guides/*.md` shipped with the package.
-2. **User** — files under the directory named by `guides-dir` (resolved relative to the config file's parent directory), or the convention path `<cwd>/.sdlc/guides/` when `guides-dir` is unset. Must contain `test/` and/or `style/` subdirectories with `*.md` files.
+1. **Bundled** — `src/sdlc/{test,style,role}-guides/*.md` shipped with the package.
+2. **User** — files under the directory named by `guides-dir` (resolved relative to the config file's parent directory), or the convention path `<cwd>/.sdlc/guides/` when `guides-dir` is unset. Must contain `test/`, `style/`, and/or `role/` subdirectories with `*.md` files.
 
 The stem is the filename without `.md`. Each discovered guide is exposed at `sdlc://guides/{kind}/{stem}`.
+
+All three kinds (`test`, `style`, `role`) are configured via `guide-map`. `test` and `style` guides are resolved from changed file paths; `role` guides are listed by name via `sdlc_roles`, read at `sdlc://guides/role/<stem>`, and selected explicitly, with their `guide-map.role` entries scoping where the selected role's findings apply. No review path consumes a selected role yet.
 
 ### Config file
 
@@ -57,13 +63,16 @@ The stem is the filename without `.md`. Each discovered guide is exposed at `sdl
   "guides-dir": ".sdlc/guides",
   "guide-map": {
     "test":  { "**/*.py": ["python", "pytest-patterns"] },
-    "style": { "**/*.py": ["python"], "**/*.md": ["markdown"] }
+    "style": { "**/*.py": ["python"], "**/*.md": ["markdown"] },
+    "role":  { "src/**/*.py": ["architect"] }
   }
 }
 ```
 
-- `guides-dir` — path to a directory containing `test/` and/or `style/` subdirs of `*.md` guides. Resolved relative to the config file's parent directory. Defaults to the convention path `<cwd>/.sdlc/guides`.
-- `guide-map` — namespace-split map (`test` / `style`). Each namespace maps glob patterns to lists of guide stems. A file picks up the union of guides from every pattern it matches in the requested namespace. Patterns are matched via [`pathlib.PurePath.full_match`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.full_match) against the full relative path — see the Python docs for exact semantics. `**` matches any number of path components, so `**/*.py` matches Python files at any depth and `tests/**/*.py` matches them only under `tests/`. Bare patterns like `Dockerfile` are anchored to the root; use `**/Dockerfile` to match at any depth.
+The example above is illustrative: `pytest-patterns`, the `style` `**/*.py` → `python` entry, and the `architect` role are hypothetical user-supplied entries. Only `python` (test), `markdown` (style), and the `general-purpose` role ship by default — see `sdlc://config/default` for the authoritative bundled map.
+
+- `guides-dir` — path to a directory containing `test/`, `style/`, and/or `role/` subdirs of `*.md` guides. Resolved relative to the config file's parent directory. Defaults to the convention path `<cwd>/.sdlc/guides`.
+- `guide-map` — namespace-split map (`test` / `style` / `role`). Each namespace maps glob patterns to lists of stems. A file picks up the union of stems from every pattern it matches in the requested namespace. Patterns are matched via [`pathlib.PurePath.full_match`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.full_match) against the full relative path — see the Python docs for exact semantics. `**` matches any number of path components, so `**/*.py` matches Python files at any depth and `tests/**/*.py` matches them only under `tests/`. Bare patterns like `Dockerfile` are anchored to the root; use `**/Dockerfile` to match at any depth.
 
 ### Resolution order
 
@@ -81,12 +90,12 @@ The stem is the filename without `.md`. Each discovered guide is exposed at `sdl
 User config merges onto the default per the following rules. Removing or replacing a default pattern requires writing the same pattern key with the desired value (or `[]` to disable):
 
 - **Top level:** `guides-dir` from user replaces default.
-- **`guide-map`:** per-namespace deep merge — user's `test` dict updates the default's `test` dict; same for `style`. Unmentioned namespaces pass through unchanged.
+- **`guide-map`:** per-namespace deep merge — user's `test` dict updates the default's `test` dict; same for `style` and `role`. Unmentioned namespaces pass through unchanged.
 - **Inside a namespace:** pattern keys merge shallowly — a user pattern key replaces the default's same-pattern entry; disjoint pattern keys coexist.
 
 ### Skill integration
 
-The `implement`, `test`, and `review` skills do not hardcode guide URIs. Each calls `sdlc_guides_for(paths, kind)` with the relevant file paths and reads every returned URI. To add a guide for a new language or convention, drop the markdown file in `.sdlc/guides/{test,style}/` and (if the file should be picked up for a path that the default map doesn't cover) add an entry to `guide-map` in `.sdlc/config.json`.
+The `implement`, `test`, and `review` skills do not hardcode guide URIs. Each calls `sdlc_guides_for(paths, kind)` with the relevant file paths and reads every returned URI. To add a guide for a new language or convention, drop the markdown file in `.sdlc/guides/{test,style}/` and (if the file should be picked up for a path that the default map doesn't cover) add an entry to `guide-map` in `.sdlc/config.json`. Review roles follow the same configuration pattern — a markdown file under `.sdlc/guides/role/` plus a `guide-map.role` entry (the `sdlc_role` skill authors both) — but, unlike `test` and `style` guides, are selected by name rather than resolved from paths via `sdlc_guides_for`.
 
 ## Installation & Setup
 
@@ -141,6 +150,7 @@ sdlc/
     ├── guides.py                    ← Config loader, guide discovery, resolver
     ├── pr_state.py                  ← gh wrappers and PR-state dispatch for sdlc_implement
     ├── config.json                  ← Package-default config (guide-map)
+    ├── role-template.md             ← Bundled role-document template
     ├── AGENTS.md                    ← you are here (canonical)
     ├── skills/                      ← Canonical skill definitions (read by server)
     │   ├── issue.md
@@ -151,11 +161,14 @@ sdlc/
     │   ├── commit.md
     │   ├── pr.md
     │   ├── review.md
+    │   ├── role.md
     │   └── understand-chat.md
     ├── test-guides/                 ← Bundled test guides (extend via .sdlc/guides/test/)
     │   └── python.md
-    └── style-guides/                ← Bundled style guides (extend via .sdlc/guides/style/)
-        └── markdown.md
+    ├── style-guides/                ← Bundled style guides (extend via .sdlc/guides/style/)
+    │   └── markdown.md
+    └── role-guides/                 ← Bundled review roles (extend via .sdlc/guides/role/)
+        └── general-purpose.md
 ```
 
 ## Pipeline Overview

--- a/src/sdlc/config.json
+++ b/src/sdlc/config.json
@@ -5,6 +5,9 @@
     },
     "style": {
       "**/*.md": ["markdown"]
+    },
+    "role": {
+      "**/*": ["general-purpose"]
     }
   }
 }

--- a/src/sdlc/guides.py
+++ b/src/sdlc/guides.py
@@ -1,9 +1,13 @@
 """Guide config loading, discovery, and resolution.
 
-Guides are markdown files served as MCP resources. Two namespaces exist:
-``test`` and ``style``. Bundled guides ship with the package; user guides
-extend or override them via a ``.sdlc/config.json`` file (path overridable
-via the ``SDLC_CONFIG`` environment variable).
+Guides are markdown files served as MCP resources. The ``test``, ``style``,
+and ``role`` namespaces are all configured through ``guide-map`` (glob ->
+stems) and discovered by stem. ``test`` and ``style`` guides are resolved
+from changed file paths; ``role`` guides are selected by name, and their
+``guide-map`` entries scope where a selected role's findings apply. Bundled
+guides ship with the package; user guides extend or override them via a
+``.sdlc/config.json`` file (path overridable via the ``SDLC_CONFIG``
+environment variable).
 """
 
 from __future__ import annotations
@@ -18,7 +22,7 @@ from pathlib import Path, PurePath
 PACKAGE_DIR = Path(__file__).resolve().parent
 DEFAULT_CONFIG_PATH = PACKAGE_DIR / "config.json"
 
-KINDS = ("test", "style")
+KINDS = ("test", "style", "role")
 ALLOWED_TOP_LEVEL_KEYS = {"guides-dir", "guide-map"}
 CAMEL_CASE_HINTS = {"guidesDir": "guides-dir", "guideMap": "guide-map"}
 
@@ -153,6 +157,11 @@ def read_guide(
     if path is None:
         return f"Error: guide '{kind}/{stem}' not found"
     return path.read_text()
+
+
+def list_roles(discovered: dict[tuple[str, str], Path]) -> list[str]:
+    """Return the sorted stems of all discovered role guides."""
+    return sorted(stem for (kind, stem) in discovered if kind == "role")
 
 
 def load_state(

--- a/src/sdlc/role-guides/general-purpose.md
+++ b/src/sdlc/role-guides/general-purpose.md
@@ -1,0 +1,17 @@
+---
+name: general-purpose
+---
+
+# Role: general-purpose
+
+Key words MUST, MUST NOT, SHOULD, and SHOULD NOT are interpreted as described in RFC 2119.
+
+The files this role's findings are scoped to are configured in `guide-map.role`; by default it is mapped to `**/*` (the whole diff). The role MAY read any file for context.
+
+## Lens / identity
+
+A balanced, general-purpose reviewer that evaluates the entire diff for correctness, clarity, test coverage, and adherence to the project's test- and style-guides without specializing in any single concern. It reads the changed code in the context of the modules it touches and surfaces the issues a thorough human reviewer would raise across correctness, code quality, tests, style, and documentation.
+
+## Blocking policy
+
+Violations of MUST or SHALL rules in any applicable project guide are blocking and MUST be resolved before approval. SHOULD / SHOULD NOT observations, stylistic suggestions, and optional quality improvements are advisory and MUST NOT block.

--- a/src/sdlc/role-template.md
+++ b/src/sdlc/role-template.md
@@ -1,0 +1,17 @@
+---
+name: <name>
+---
+
+# Role: <name>
+
+Key words MUST, MUST NOT, SHOULD, and SHOULD NOT are interpreted as described in RFC 2119.
+
+This template defines the required structure of a review-role document. A role document MUST contain the two body sections below, with these exact headings. A role declares only its reviewing perspective here; the files its findings are scoped to are configured separately in `guide-map.role` (a glob-to-role map in `.sdlc/config.json`), the same way `test` and `style` guides are mapped.
+
+## Lens / identity
+
+Describe the reviewing perspective this role embodies: what it cares about, what expertise it simulates, and the kinds of findings it surfaces. Be specific — an `architect` role evaluates module boundaries, coupling, and layering; a `product-manager` role evaluates whether the change serves the stated user need.
+
+## Blocking policy
+
+State which finding classes this role treats as blocking versus advisory, for this project. The default convention is that violations of MUST / SHALL guide rules are blocking and SHOULD / MAY observations are advisory; adapt it to the role and the project.

--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -10,6 +10,7 @@ from sdlc import guides, pr_state
 PACKAGE_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = PACKAGE_DIR / "skills"
 AGENTS_MD_PATH = PACKAGE_DIR / "AGENTS.md"
+ROLE_TEMPLATE_PATH = PACKAGE_DIR / "role-template.md"
 
 _state = guides.load_state(cwd=Path.cwd(), package_dir=PACKAGE_DIR)
 
@@ -226,6 +227,39 @@ async def sdlc_guides_for(
     return [f"sdlc://guides/{kind}/{stem}" for stem in stems]
 
 
+@mcp.tool()
+async def sdlc_roles() -> list[str]:
+    """List the available review roles as resource URIs.
+
+    Returns a list of `sdlc://guides/role/{stem}` URIs, one per discovered
+    role (bundled or user-supplied). Read each URI to obtain the role's lens,
+    blocking policy, and focus globs.
+    """
+    return [
+        f"sdlc://guides/role/{stem}" for stem in guides.list_roles(_state.discovered)
+    ]
+
+
+@mcp.tool()
+async def sdlc_role(name: str) -> str:
+    """Author a review role document.
+
+    Use when the user says "role", "create a role", "add a review role",
+    or similar. Drafts a role document (lens, blocking policy, focus globs)
+    and, on approval, writes it to `.sdlc/guides/role/<name>.md`.
+
+    Args:
+        name: The role name (stem) to author, e.g. "architect".
+    """
+    skill = _read_skill("role")
+    template = _read_file(ROLE_TEMPLATE_PATH)
+    return (
+        f"{skill}\n---\n\n"
+        f"Target role: {name}\n\n"
+        f"Role document template:\n\n{template}"
+    )
+
+
 @mcp.resource("sdlc://guides/test/{stem}")
 async def get_test_guide(stem: str) -> str:
     """Return the test guide identified by `stem` (e.g. "python")."""
@@ -238,10 +272,22 @@ async def get_style_guide(stem: str) -> str:
     return guides.read_guide("style", stem, _state.discovered)
 
 
+@mcp.resource("sdlc://guides/role/{stem}")
+async def get_role_guide(stem: str) -> str:
+    """Return the role guide identified by `stem` (e.g. "general-purpose")."""
+    return guides.read_guide("role", stem, _state.discovered)
+
+
 @mcp.resource("sdlc://config/default")
 async def get_default_config() -> str:
     """Return the package-default config.json content."""
     return _read_file(guides.DEFAULT_CONFIG_PATH)
+
+
+@mcp.resource("sdlc://role-template")
+async def role_template() -> str:
+    """Return the bundled role-document template."""
+    return _read_file(ROLE_TEMPLATE_PATH)
 
 
 @mcp.resource("sdlc://agents-md")

--- a/src/sdlc/skills/role.md
+++ b/src/sdlc/skills/role.md
@@ -1,0 +1,121 @@
+---
+name: role
+description: >
+  Author a review role. Use this skill whenever the user says "create a
+  role", "add a review role", or "author a review role" (not a request to
+  run a review under an existing role). Gathers the role's lens and blocking
+  policy and, on approval, writes the role document to
+  .sdlc/guides/role/<name>.md and maps its focus globs into guide-map.role
+  in .sdlc/config.json.
+subagent:
+  support: optional
+  type: general-purpose
+  artifacts:
+    - role_name
+    - role_path
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Role Skill
+
+Author a reusable review role — a named lens (e.g. `architect`, `product-manager`) intended to be run by a review flow to produce findings. A role document declares only the reviewing perspective and the project-specific policy for what counts as blocking; the files a role's findings are scoped to are configured separately in `guide-map.role` (a glob-to-role map in `.sdlc/config.json`), exactly as `test` and `style` guides are mapped. This skill drafts the role document and the mapping entry interactively and, on approval, writes both. Review-time role selection is not yet wired — roles authored here are stored and discoverable for that forthcoming consumption.
+
+## Pipeline Context
+
+This skill authors a role for future consumption by a review flow — no review path selects a role today. It is invoked on demand, not as a fixed stage of the `issue → implement → test → commit → pr → review` pipeline. Roles authored here are discovered by name and exposed via the `sdlc_roles` tool and the `sdlc://guides/role/<name>` resource; their glob scope lives in `guide-map.role`.
+
+## Implementation Notes
+
+The role document is seeded from the bundled template appended to this skill's tool output (also available as the `sdlc://role-template` resource). The drafting loop is conversational: gather each part, render the full role document plus its `guide-map.role` entry, and obtain explicit approval before writing — there is no separate structured-planning interface for this skill.
+
+## Invariants
+
+- MUST seed the role document from the provided role-document template.
+- The role document MUST contain the two body sections, with their exact headings: `## Lens / identity` and `## Blocking policy`. It MUST NOT embed glob patterns — scope lives in `guide-map.role`.
+- MUST reject a `<name>` that is empty or contains path separators or `..` before drafting; the `sdlc_role` endpoint does not pre-validate the name, so this guard is the agent's responsibility.
+- MUST NOT write either the role document or the config mapping until the user explicitly approves the draft of both.
+- MUST write the approved role document to `.sdlc/guides/role/<name>.md`, creating the `.sdlc/guides/role/` directory if it does not exist.
+- MUST map the role's focus globs under `guide-map.role` in `.sdlc/config.json` — a `{ "<glob>": ["<name>"] }` entry per glob, using `pathlib.PurePath.full_match` pattern syntax (the same matching as `test` and `style` guides). Create `.sdlc/config.json` (with a `guide-map.role` object) if it does not exist, and merge into any existing `guide-map` without disturbing other entries.
+- MUST NOT proceed to any other pipeline step autonomously.
+
+## Arguments
+
+The MCP endpoint supplies the role `name` (the stem) appended below this skill prompt as `Target role: <name>`, along with the role-document template. The `name` determines the role document path `.sdlc/guides/role/<name>.md` and the stem used in its `guide-map.role` entries.
+
+## Subagent Execution (Optional)
+
+This skill MAY be executed in an isolated subagent to preserve parent context. When invoked with a `--subagent` flag, execute according to your tool:
+
+**Claude Code:**
+- MUST spawn a general-purpose subagent using the Agent tool with this brief:
+  > You are executing the **`role`** skill from the SDLC pipeline tooling.
+  > 1. Read the project instructions in `AGENTS.md`
+  > 2. Read and execute the complete workflow defined in this skill's markdown
+  > 3. Follow every step faithfully, especially the Invariants section
+  > 4. Return a structured summary: key artifacts (`role_name`, `role_path`) and the `guide-map.role` globs mapped to the role
+
+- The subagent drafts the role document and its mapping and returns them for approval; nothing is written until the user explicitly approves (the approval-gate Invariant applies inside the subagent — it MUST NOT write before approval). When the subagent returns, reproduce its full output to the user exactly as written so the user can give informed approval — do not summarize, condense, paraphrase, or omit sections, and do not repeat work or add your own commentary.
+
+**Other LLM assistants:**
+- Subagent execution may not be supported in your tool. Execute the skill inline following the normal workflow.
+
+## Workflow
+
+### Checklist
+
+1. Resolve the target name and path
+2. Establish the lens / identity
+3. Define the blocking policy
+4. Define the focus globs (the guide-map.role mapping)
+5. Draft the role document and the mapping
+6. Show the draft for approval
+7. Write the role document and update the config
+8. Return the paths
+
+### 1. Resolve the target name and path
+
+The target role name is supplied as `Target role: <name>`. The role document path is `.sdlc/guides/role/<name>.md`; its scope is mapped under `guide-map.role` in `.sdlc/config.json`.
+
+- If a file already exists at the role document path, the user MUST be asked whether to overwrite it before proceeding.
+- If `<name>` collides with a bundled role (e.g. `general-purpose`), warn the user that the authored file will shadow the bundled role for this project.
+- If `<name>` is empty or contains path separators, reject it and ask the user for a valid stem.
+
+### 2. Establish the lens / identity
+
+Interview the user for the reviewing perspective this role embodies: what it evaluates, what expertise it simulates, and the kinds of findings it surfaces. Be concrete — an `architect` role evaluates module boundaries, coupling, and layering; a `product-manager` role evaluates whether the change serves the stated user need.
+
+### 3. Define the blocking policy
+
+Determine, with the user, which classes of finding this role treats as blocking versus advisory for this project. The default convention is that violations of MUST / SHALL guide rules are blocking and SHOULD / MAY observations are advisory; adapt it to the role and project.
+
+### 4. Define the focus globs
+
+Determine, with the user, the glob patterns that scope where this role's findings apply; these become `guide-map.role` entries mapping each glob to `<name>` in `.sdlc/config.json`. `**/*` covers the whole diff. If the user does not specify any, default to `**/*`. Patterns use `pathlib.PurePath.full_match` semantics (the same as `test` and `style` guide-map entries). Remind the user that the role MAY read any file for context but raises findings only within these globs.
+
+### 5. Draft the role document and the mapping
+
+Render the complete role document from the template (the two body sections, no embedded globs) and the `guide-map.role` mapping entries. The headings MUST match the template exactly. For a concrete example of a well-formed role, see the bundled `general-purpose` role (`sdlc://guides/role/general-purpose`).
+
+### 6. Show the draft for approval
+
+Present the full draft — name, the role document path and body, and the `guide-map.role` entries to be written to `.sdlc/config.json` — to the user. Nothing MUST be written until the user explicitly approves.
+
+### 7. Write the role document and update the config
+
+After approval:
+
+- Create `.sdlc/guides/role/<name>.md` (creating `.sdlc/guides/role/` if needed) with the approved role document.
+- Add the role's glob entries under `guide-map.role` in `.sdlc/config.json`, creating the file and the `guide-map` / `role` objects if absent and preserving any existing entries.
+
+### 8. Return the paths
+
+Print the written role document path and the `guide-map.role` entries added, and note that the role is now discoverable via `sdlc_roles()` and readable at `sdlc://guides/role/<name>`.
+
+## Edge Cases
+
+- **File already exists at the role document path:** Ask before overwriting; never silently clobber a user's role.
+- **Name collides with a bundled role:** Warn that the user file shadows the bundled role for this project.
+- **No focus globs provided:** Default to `**/*` (whole diff) rather than writing an empty list.
+- **`.sdlc/config.json` already has a `guide-map`:** Merge the role's entries into `guide-map.role`, preserving existing `test` / `style` / `role` entries; do not overwrite the file wholesale.
+- **Invalid name (path separators, empty):** Reject and ask the user for a valid stem.

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -6,6 +6,7 @@ import pytest
 
 from sdlc.guides import (
     discover_guides,
+    list_roles,
     load_package_default,
     load_state,
     load_user_config,
@@ -23,7 +24,7 @@ def test_load_package_default_should_return_shipped_config():
     When:
         load_package_default() is called with no arguments.
     Then:
-        It should return a dict with kebab-case 'guide-map' covering test and style.
+        It should return a dict with kebab-case 'guide-map' covering test, style, and role.
     """
     # Act
     result = load_package_default()
@@ -32,6 +33,7 @@ def test_load_package_default_should_return_shipped_config():
     assert "guide-map" in result
     assert result["guide-map"]["test"]["**/*.py"] == ["python"]
     assert result["guide-map"]["style"]["**/*.md"] == ["markdown"]
+    assert result["guide-map"]["role"]["**/*"] == ["general-purpose"]
 
 
 def test_load_user_config_should_return_none_when_file_and_env_missing(tmp_path, monkeypatch):
@@ -259,6 +261,33 @@ def test_load_user_config_should_raise_when_guide_map_kind_unknown(tmp_path, mon
     # Act & assert
     with pytest.raises(ValueError, match="docs"):
         load_user_config(tmp_path)
+
+
+def test_load_user_config_should_accept_guide_map_role_kind(tmp_path, monkeypatch):
+    """Test guide-map accepts the 'role' kind as a first-class namespace.
+
+    Given:
+        A guide-map declaring a 'role' namespace.
+    When:
+        load_user_config(cwd) is called.
+    Then:
+        It should return the parsed config with the role namespace intact.
+    """
+    # Arrange
+    monkeypatch.delenv("SDLC_CONFIG", raising=False)
+    sdlc_dir = tmp_path / ".sdlc"
+    sdlc_dir.mkdir()
+    (sdlc_dir / "config.json").write_text(
+        '{"guide-map": {"role": {"src/**/*.py": ["architect"]}}}'
+    )
+
+    # Act
+    result = load_user_config(tmp_path)
+
+    # Assert
+    assert result is not None
+    config, _ = result
+    assert config["guide-map"]["role"]["src/**/*.py"] == ["architect"]
 
 
 def test_load_user_config_should_raise_when_top_level_not_object(tmp_path, monkeypatch):
@@ -611,6 +640,87 @@ def test_discover_guides_should_warn_when_guides_dir_missing(tmp_path, recwarn):
     assert any("nope" in str(w.message) for w in recwarn)
 
 
+def test_discover_guides_should_find_bundled_role_when_role_guides_present(tmp_path):
+    """Test bundled role guides are discovered under role-guides/.
+
+    Given:
+        A package dir with role-guides/general-purpose.md and no user dir.
+    When:
+        discover_guides is called.
+    Then:
+        The bundled role is discovered as ('role', 'general-purpose').
+    """
+    # Arrange
+    pkg = tmp_path / "pkg"
+    (pkg / "role-guides").mkdir(parents=True)
+    (pkg / "role-guides" / "general-purpose.md").write_text("# Role")
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    config = {"guide-map": {}}
+
+    # Act
+    result = discover_guides(config, pkg, cwd, None)
+
+    # Assert
+    assert result[("role", "general-purpose")] == (
+        pkg / "role-guides" / "general-purpose.md"
+    )
+
+
+def test_discover_guides_should_merge_user_role_at_convention_path(tmp_path):
+    """Test user role guides at .sdlc/guides/role/ are discovered.
+
+    Given:
+        A bundled role and a user role at .sdlc/guides/role/architect.md.
+    When:
+        discover_guides is called with no user_config_dir.
+    Then:
+        Both the bundled and user roles are present.
+    """
+    # Arrange
+    pkg = tmp_path / "pkg"
+    (pkg / "role-guides").mkdir(parents=True)
+    (pkg / "role-guides" / "general-purpose.md").write_text("# GP")
+    cwd = tmp_path / "proj"
+    (cwd / ".sdlc" / "guides" / "role").mkdir(parents=True)
+    (cwd / ".sdlc" / "guides" / "role" / "architect.md").write_text("# Arch")
+    config = {"guide-map": {}}
+
+    # Act
+    result = discover_guides(config, pkg, cwd, None)
+
+    # Assert
+    assert ("role", "general-purpose") in result
+    assert ("role", "architect") in result
+
+
+def test_discover_guides_should_prefer_user_role_when_stems_collide(tmp_path):
+    """Test a user role with the same stem replaces the bundled one.
+
+    Given:
+        Bundled and user 'role/general-purpose' guides both exist.
+    When:
+        discover_guides is called.
+    Then:
+        The discovered path for ('role', 'general-purpose') is the user file.
+    """
+    # Arrange
+    pkg = tmp_path / "pkg"
+    (pkg / "role-guides").mkdir(parents=True)
+    (pkg / "role-guides" / "general-purpose.md").write_text("bundled")
+    cwd = tmp_path / "proj"
+    user_roles = cwd / ".sdlc" / "guides" / "role"
+    user_roles.mkdir(parents=True)
+    (user_roles / "general-purpose.md").write_text("user")
+    config = {"guide-map": {}}
+
+    # Act
+    result = discover_guides(config, pkg, cwd, None)
+
+    # Assert
+    assert result[("role", "general-purpose")].read_text() == "user"
+
+
 def test_resolve_guides_should_return_stems_when_single_pattern_matches(tmp_path):
     """Test a single matching pattern returns its mapped stems.
 
@@ -861,6 +971,54 @@ def test_read_guide_should_return_error_when_stem_unknown():
     assert "not found" in result.lower()
 
 
+def test_list_roles_should_return_sorted_role_stems(tmp_path):
+    """Test list_roles returns only role stems, sorted, ignoring other kinds.
+
+    Given:
+        A discovered map with several role stems plus test and style entries.
+    When:
+        list_roles is called.
+    Then:
+        Only the role stems are returned, in sorted order.
+    """
+    # Arrange
+    discovered = {
+        ("role", "security"): tmp_path / "s.md",
+        ("role", "architect"): tmp_path / "a.md",
+        ("test", "python"): tmp_path / "p.md",
+        ("style", "markdown"): tmp_path / "m.md",
+    }
+
+    # Act
+    result = list_roles(discovered)
+
+    # Assert
+    assert result == ["architect", "security"]
+
+
+def test_list_roles_should_return_empty_when_no_roles(tmp_path):
+    """Test list_roles returns an empty list when no role guides are discovered.
+
+    Given:
+        A discovered map containing only test and style guides.
+    When:
+        list_roles is called.
+    Then:
+        An empty list is returned.
+    """
+    # Arrange
+    discovered = {
+        ("test", "python"): tmp_path / "p.md",
+        ("style", "markdown"): tmp_path / "m.md",
+    }
+
+    # Act
+    result = list_roles(discovered)
+
+    # Assert
+    assert result == []
+
+
 def test_load_state_should_use_package_default_when_no_user_config(tmp_path, monkeypatch):
     """Test load_state with no user config falls back to the package default map.
 
@@ -929,6 +1087,26 @@ def test_load_state_should_discover_bundled_guides(tmp_path, monkeypatch):
     # Assert
     assert ("test", "python") in state.discovered
     assert ("style", "markdown") in state.discovered
+
+
+def test_load_state_should_discover_bundled_general_purpose_role(tmp_path, monkeypatch):
+    """Test the state's discovered map includes the bundled general-purpose role.
+
+    Given:
+        A clean working directory with no user guides.
+    When:
+        load_state is called.
+    Then:
+        The bundled ('role', 'general-purpose') guide is present in discovered.
+    """
+    # Arrange
+    monkeypatch.delenv("SDLC_CONFIG", raising=False)
+
+    # Act
+    state = load_state(cwd=tmp_path)
+
+    # Assert
+    assert ("role", "general-purpose") in state.discovered
 
 
 def test_load_state_should_honor_custom_package_dir(tmp_path, monkeypatch):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -9,15 +9,19 @@ from sdlc.pr_state import Finding, Findings, GhUnavailable, PrContext
 from sdlc.server import (
     agents_md,
     get_default_config,
+    get_role_guide,
     get_style_guide,
     get_test_guide,
     knowledge_graph,
+    role_template,
     sdlc_commit,
     sdlc_guides_for,
     sdlc_implement,
     sdlc_issue,
     sdlc_pr,
     sdlc_review,
+    sdlc_role,
+    sdlc_roles,
     sdlc_test,
     sdlc_understand_chat,
 )
@@ -461,6 +465,136 @@ async def test_get_default_config_should_return_shipped_json():
     assert "guide-map" in parsed
     assert "test" in parsed["guide-map"]
     assert "style" in parsed["guide-map"]
+    assert "role" in parsed["guide-map"]
+
+
+@pytest.mark.asyncio
+async def test_get_role_guide_should_return_bundled_general_purpose_role():
+    """Test the role/general-purpose URI serves the bundled default role.
+
+    Given:
+        The package bundles src/sdlc/role-guides/general-purpose.md.
+    When:
+        get_role_guide(stem="general-purpose") is called.
+    Then:
+        It should return the general-purpose role content.
+    """
+    # Act
+    result = await get_role_guide(stem="general-purpose")
+
+    # Assert
+    assert "# Role: general-purpose" in result
+
+
+@pytest.mark.asyncio
+async def test_get_role_guide_should_return_error_when_stem_unknown():
+    """Test an unknown role guide stem returns an error message.
+
+    Given:
+        A stem with no corresponding role file.
+    When:
+        get_role_guide(stem="nonexistent") is called.
+    Then:
+        It should return a "not found" message.
+    """
+    # Act
+    result = await get_role_guide(stem="nonexistent")
+
+    # Assert
+    assert "not found" in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_role_template_should_return_template_content():
+    """Test the role-template resource serves the bundled role template.
+
+    Given:
+        The package bundles src/sdlc/role-template.md.
+    When:
+        role_template() is called.
+    Then:
+        It should return the two required body section headings.
+    """
+    # Act
+    result = await role_template()
+
+    # Assert
+    assert "## Lens / identity" in result
+    assert "## Blocking policy" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_roles_should_include_general_purpose_uri():
+    """Test sdlc_roles lists the bundled general-purpose role as a URI.
+
+    Given:
+        The package bundles the general-purpose role.
+    When:
+        sdlc_roles() is called.
+    Then:
+        The general-purpose role URI is present in the result.
+    """
+    # Act
+    result = await sdlc_roles()
+
+    # Assert
+    assert "sdlc://guides/role/general-purpose" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_roles_should_return_role_uris():
+    """Test every entry sdlc_roles returns is a role resource URI.
+
+    Given:
+        The discovered roles (at least the bundled general-purpose).
+    When:
+        sdlc_roles() is called.
+    Then:
+        Every returned entry is an sdlc://guides/role/ URI.
+    """
+    # Act
+    result = await sdlc_roles()
+
+    # Assert
+    assert all(uri.startswith("sdlc://guides/role/") for uri in result)
+
+
+@pytest.mark.asyncio
+async def test_sdlc_role_should_return_skill_with_target_role():
+    """Test sdlc_role returns the role skill with the target role appended.
+
+    Given:
+        A role name.
+    When:
+        sdlc_role(name="architect") is called.
+    Then:
+        It should return the role skill content with "Target role: architect".
+    """
+    # Act
+    result = await sdlc_role(name="architect")
+
+    # Assert
+    assert "# Role Skill" in result
+    assert "Target role: architect" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_role_should_inline_role_template():
+    """Test sdlc_role inlines the role-document template into the prompt.
+
+    Given:
+        A role name.
+    When:
+        sdlc_role(name="architect") is called.
+    Then:
+        It should include the template's two required body section headings.
+    """
+    # Act
+    result = await sdlc_role(name="architect")
+
+    # Assert
+    assert "## Lens / identity" in result
+    assert "## Blocking policy" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Add review roles as a third guide kind so reviews can later run through named lenses (e.g. `architect`, `product-manager`). Roles are discovered like test- and style-guides — bundled under `src/sdlc/role-guides/` and user-extensible under `.sdlc/guides/role/` — but selected by name rather than glob-matched, so they never participate in `guide-map`. This change delivers only the role infrastructure (discovery, a bundled default role, a template, and an authoring tool); it does not change the review flow.

The discovery/guide-map split uses a new `DISCOVERED_KINDS` constant consumed only by `discover_guides`, leaving `KINDS` — and therefore guide-map validation and resolution — untouched, so a `guide-map.role` entry is rejected automatically. The role-document template ships at the package root rather than under `role-guides/` so it is not surfaced as a phantom role.

Closes #15

## Proposed changes

### Role guide kind (`guides.py`)

Add `DISCOVERED_KINDS = (*KINDS, "role")` and use it in `discover_guides` so bundled `role-guides/*.md` and user `.sdlc/guides/role/*.md` are discovered by name. Add `list_roles(discovered)` returning the sorted role stems. `KINDS` stays `("test", "style")`, so `guide-map` continues to reject a `role` namespace and roles are never glob-matched.

### MCP surface (`server.py`)

Add a `sdlc://guides/role/{stem}` resource and a `sdlc://role-template` resource, an `sdlc_roles()` tool returning `sdlc://guides/role/{stem}` URIs (mirroring `sdlc_guides_for`), and an `sdlc_role(name)` tool that returns the role authoring skill plus a `Target role: <name>` directive and the inlined role-document template.

### Bundled role content and authoring skill

Add a default `general-purpose` role (whole-diff focus globs; MUST/SHALL violations blocking), a `role-template.md` defining the three required sections (Lens / identity, Blocking policy, Focus globs), and a `role` skill that interactively authors a role document and writes it to `.sdlc/guides/role/<name>.md` behind an approval gate.

### Documentation

Document the `role` kind, the new tools and resources, and the bundled files in `AGENTS.md` and the `README`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_guides` | A discovered map with role, test, and style entries | `list_roles` is called | Returns only the role stems, sorted | Role-stem filtering and ordering |
| 2 | `test_guides` | A discovered map with no role entries | `list_roles` is called | Returns an empty list | Empty-roles case |
| 3 | `test_guides` | A package with a bundled `role-guides/general-purpose.md` | `discover_guides` is called | Discovers the bundled role by name | Bundled role discovery |
| 4 | `test_guides` | A user `.sdlc/guides/role/architect.md` alongside a bundled role | `discover_guides` is called | Discovers both roles | User role discovery |
| 5 | `test_guides` | Bundled and user roles sharing a stem | `discover_guides` is called | The user role wins | User-shadows-bundled precedence |
| 6 | `test_guides` | A guide-map declaring a `role` namespace | `load_user_config` is called | Raises naming the role kind | guide-map role rejection |
| 7 | `test_guides` | A clean working directory | `load_state` is called | Discovers the bundled general-purpose role | load_state role discovery |
| 8 | `test_server` | The bundled general-purpose role | `get_role_guide("general-purpose")` is called | Returns the role content | Role guide resource |
| 9 | `test_server` | A stem with no role file | `get_role_guide("nonexistent")` is called | Returns a not-found message | Unknown role stem |
| 10 | `test_server` | The bundled role template | `role_template()` is called | Returns the three required section headings | Role-template resource |
| 11 | `test_server` | The discovered roles | `sdlc_roles()` is called | Includes the general-purpose role URI | sdlc_roles listing |
| 12 | `test_server` | The discovered roles | `sdlc_roles()` is called | Every entry is a role resource URI | sdlc_roles URI shape |
| 13 | `test_server` | A role name | `sdlc_role("architect")` is called | Returns the role skill with the target role | sdlc_role authoring prompt |
| 14 | `test_server` | A role name | `sdlc_role("architect")` is called | Inlines the role-document template | sdlc_role template seeding |