### PR TITLE
Rework sdlc_review to produce a local consolidated review document — Closes #16

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you have a PR template defined in your `.github` dir, the agent will follow t
 
 **6. Review the PR (Optional)**
 
-The agent calls `sdlc_review` with the PR number. It analyzes the PR against project guides (style, testing, architecture), groups findings by severity, and posts inline review comments. You approve or request changes, and the review is posted.
+The agent calls `sdlc_review` with the PR number. It runs one or more reviewer roles (N reviewers per role) over the PR diff, each confined to the files its role is mapped to, then consolidates their findings — deduped, merged across roles, highest severity wins — into a single local document at `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. The document groups findings by severity (blocking first), gives each a stable ID and a `Reference`, and pre-selects a recommended remediation per finding with alternatives and an `Other` slot. You review and approve the document; nothing is posted to GitHub. The document is a local artifact you (or the agent) read to drive fixups manually — `sdlc_implement` does not ingest it, so address the findings directly using each one's pre-selected remediation and fixup-mapping entry as the work list.
 
 **7. Iterate or Merge**
 
@@ -123,6 +123,7 @@ sdlc/
         │   ├── role.md
         │   └── understand-chat.md
         ├── role-template.md        # Bundled role-document template
+        ├── review-template.md      # Bundled consolidated-review-document template
         ├── test-guides/            # Testing conventions (served as MCP resources)
         │   └── python.md
         ├── style-guides/           # Style conventions (served as MCP resources)
@@ -140,9 +141,10 @@ sdlc/
 | `sdlc_test` | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | Stage and commit changes with atomic commits |
 | `sdlc_pr` | Review changes and create a draft pull request |
-| `sdlc_review` | Review an open pull request for compliance and quality |
+| `sdlc_review` | Review an open PR and write a consolidated local review document under `.sdlc/reviews/` |
 | `sdlc_understand_chat` | Query the codebase knowledge graph |
 | `sdlc_roles` | List the available review roles |
+| `sdlc_role_scope` | Reverse-lookup the changed files a role's findings are confined to |
 | `sdlc_role` | Author a review role document |
 
 ### MCP Resources
@@ -153,12 +155,13 @@ sdlc/
 | `sdlc://guides/style/markdown` | Markdown style conventions |
 | `sdlc://guides/role/general-purpose` | Default review role |
 | `sdlc://role-template` | Role-document template |
+| `sdlc://review-template` | Consolidated-review-document template |
 | `sdlc://agents-md` | Project-level agent instructions |
 | `sdlc://knowledge-graph` | Codebase knowledge graph (if generated) |
 
 ## What You Get
 
-The pipeline enforces disciplined commits — atomic, well-structured, with conventional-commit messages that make your history readable. It emphasizes test-first planning, generating comprehensive test specs before implementation. Code quality is enforced through guide-based compliance review with inline comments. Every action is presented for review before execution, so you never have unwanted surprises. When you get PR feedback, you loop back to implementation, refine, and iterate. The system is tool-agnostic — any MCP-compatible client can connect. For large codebases, you can generate lightweight knowledge graphs to give the agent architectural context without shipping megabytes of source code as context.
+The pipeline enforces disciplined commits — atomic, well-structured, with conventional-commit messages that make your history readable. It emphasizes test-first planning, generating comprehensive test specs before implementation. Code quality is enforced through guide-based, role-driven review that produces a consolidated local review document — an actionable, option-per-finding remediation plan you keep under `.sdlc/reviews/`. Every action is presented for review before execution, so you never have unwanted surprises. When you get PR feedback, you loop back to implementation, refine, and iterate. The system is tool-agnostic — any MCP-compatible client can connect. For large codebases, you can generate lightweight knowledge graphs to give the agent architectural context without shipping megabytes of source code as context.
 
 ## Documentation
 

--- a/src/sdlc/AGENTS.md
+++ b/src/sdlc/AGENTS.md
@@ -17,10 +17,11 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | `sdlc_test` | 3rd | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | 4th | Stage and commit changes with atomic commits |
 | `sdlc_pr` | 5th | Review changes and create a draft pull request |
-| `sdlc_review` | 6th | Review an open pull request for compliance and quality |
+| `sdlc_review` | 6th | Review an open PR and write a consolidated local review document under `.sdlc/reviews/` (no GitHub posting) |
 | `sdlc_understand_chat` | — | Query the codebase knowledge graph |
 | `sdlc_guides_for` | — | Resolve which test or style guides apply to a list of file paths |
 | `sdlc_roles` | — | List the available review roles as resource URIs |
+| `sdlc_role_scope` | — | Reverse-lookup the changed files a role's findings are confined to (over the merged `guide-map.role`) |
 | `sdlc_role` | — | Author a review role document (lens, blocking policy, focus globs) |
 
 The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine implementation. `sdlc_implement` accepts either an issue number or a PR number and dispatches between three sibling skill prompts based on PR state: `implement` (fresh start, no PR yet), `implement-continue` (PR exists, no review feedback yet), and `implement-feedback` (PR has unresolved review threads or review-body comments).
@@ -34,6 +35,7 @@ The `implement`, `test`, and `commit` tools are iterative — they can be invoke
 | `sdlc://guides/role/{stem}` | Review role identified by `{stem}` — bundled or user-supplied (e.g. `general-purpose`) |
 | `sdlc://config/default` | Package-default `config.json` content (read this to discover the bundled guide-map) |
 | `sdlc://role-template` | Bundled role-document template (the Lens and Blocking policy sections) |
+| `sdlc://review-template` | Bundled consolidated-review-document template (header, severity-tiered findings, cross-cutting decisions, fixup mapping) |
 | `sdlc://agents-md` | This file (project-level agent instructions) |
 | `sdlc://knowledge-graph` | Codebase knowledge graph (if generated) |
 
@@ -52,7 +54,7 @@ Guides are discovered from two sources at startup. Within each `kind` namespace 
 
 The stem is the filename without `.md`. Each discovered guide is exposed at `sdlc://guides/{kind}/{stem}`.
 
-All three kinds (`test`, `style`, `role`) are configured via `guide-map`. `test` and `style` guides are resolved from changed file paths; `role` guides are listed by name via `sdlc_roles`, read at `sdlc://guides/role/<stem>`, and selected explicitly, with their `guide-map.role` entries scoping where the selected role's findings apply. No review path consumes a selected role yet.
+All three kinds (`test`, `style`, `role`) are configured via `guide-map`. `test` and `style` guides are resolved from changed file paths; `role` guides are listed by name via `sdlc_roles`, read at `sdlc://guides/role/<stem>`, and selected explicitly. A role's `guide-map.role` entries scope which files a reviewer running that role confines its findings to — resolved by a **reverse lookup** over `guide-map.role` (given a role stem, the globs mapped to it; the inverse of `sdlc_guides_for`'s path-to-stems direction). The `sdlc_review` tool consumes selected roles: it runs N reviewers per role, each confined to its role's mapped files (see the Review pipeline below).
 
 ### Config file
 
@@ -95,7 +97,11 @@ User config merges onto the default per the following rules. Removing or replaci
 
 ### Skill integration
 
-The `implement`, `test`, and `review` skills do not hardcode guide URIs. Each calls `sdlc_guides_for(paths, kind)` with the relevant file paths and reads every returned URI. To add a guide for a new language or convention, drop the markdown file in `.sdlc/guides/{test,style}/` and (if the file should be picked up for a path that the default map doesn't cover) add an entry to `guide-map` in `.sdlc/config.json`. Review roles follow the same configuration pattern — a markdown file under `.sdlc/guides/role/` plus a `guide-map.role` entry (the `sdlc_role` skill authors both) — but, unlike `test` and `style` guides, are selected by name rather than resolved from paths via `sdlc_guides_for`.
+The `implement`, `test`, and `review` skills do not hardcode guide URIs. Each calls `sdlc_guides_for(paths, kind)` with the relevant file paths and reads every returned URI. To add a guide for a new language or convention, drop the markdown file in `.sdlc/guides/{test,style}/` and (if the file should be picked up for a path that the default map doesn't cover) add an entry to `guide-map` in `.sdlc/config.json`. Review roles follow the same configuration pattern — a markdown file under `.sdlc/guides/role/` plus a `guide-map.role` entry (the `sdlc_role` skill authors both) — but, unlike `test` and `style` guides, are selected by name rather than resolved from paths via `sdlc_guides_for`. When `sdlc_review` runs a role, it does the reverse: a reverse lookup over `guide-map.role` returns the globs mapped to that role, and the reviewer confines its findings to the changed files those globs match (any file may still be read for context).
+
+### The `.sdlc/reviews/` convention
+
+`sdlc_review` writes a standardized local review document — it posts nothing to GitHub. Each review round is written to `.sdlc/reviews/issue-#<N>/review-<iteration>.md`, where `<N>` is the first issue the PR closes when several are linked (resolved from `closingIssuesReferences`, falling back to parsing `Closes #N` in the PR body; the connection has no ordering guarantee, so `<N>` is one closing issue, not necessarily the only one) and `<iteration>` is 1-based, one greater than the highest existing `review-*.md` for that issue. The document is structured from the bundled template (`sdlc://review-template`): a header (roles used, reviewers per role, target HEAD sha, dedup approach, severity legend, branch commit map); findings grouped by severity tier (blocking first) — each with a stable ID, title, severity, a `Reference` (`file:line`, or a file-level / issue-level reference for a line-less finding), an Issue section with evidence, a Remediation checklist where the consolidator pre-selects the recommended option (`[x]`), lists alternatives (`[ ]`), and always offers an `Other: ___` slot, an optional Tests-to-add section, and a Touched commit; plus cross-cutting-decisions and fixup-mapping sections. The document is a local artifact: the user or agent reads it and applies each finding's pre-selected remediation and fixup-mapping entry as a manual work list. It is NOT auto-consumed by `sdlc_implement` — because nothing is posted to GitHub, a subsequent `sdlc_implement` call routes to `implement-continue` (not `implement-feedback`) unless the user separately surfaces the findings.
 
 ## Installation & Setup
 
@@ -151,6 +157,7 @@ sdlc/
     ├── pr_state.py                  ← gh wrappers and PR-state dispatch for sdlc_implement
     ├── config.json                  ← Package-default config (guide-map)
     ├── role-template.md             ← Bundled role-document template
+    ├── review-template.md           ← Bundled consolidated-review-document template
     ├── AGENTS.md                    ← you are here (canonical)
     ├── skills/                      ← Canonical skill definitions (read by server)
     │   ├── issue.md
@@ -173,7 +180,7 @@ sdlc/
 
 ## Pipeline Overview
 
-The typical development flow follows this sequence. Start by drafting a GitHub issue with acceptance criteria and description. Fetch the issue, create a feature branch, enter planning phase, and design a concrete implementation plan. Execute the plan by writing code and tests, guided by project context and test conventions. Optionally, analyze code changes, evaluate existing test coverage, and generate comprehensive test specifications targeting 100% coverage of public APIs. Analyze the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. Review the branch diff and create or update a draft pull request linked to the issue. Fetch the PR, analyze it against project guides, and post inline review comments with findings.
+The typical development flow follows this sequence. Start by drafting a GitHub issue with acceptance criteria and description. Fetch the issue, create a feature branch, enter planning phase, and design a concrete implementation plan. Execute the plan by writing code and tests, guided by project context and test conventions. Optionally, analyze code changes, evaluate existing test coverage, and generate comprehensive test specifications targeting 100% coverage of public APIs. Analyze the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. Review the branch diff and create or update a draft pull request linked to the issue. Fetch the PR, review it through one or more role lenses (N reviewers per role), and consolidate the findings into a single local review document under `.sdlc/reviews/` — nothing is posted to GitHub. The document is a local artifact the user or agent reads to drive fixups manually; `sdlc_implement` does not ingest it.
 
 The `implement`, `test`, and `commit` steps are iterative — you can run them multiple times to refine the implementation based on feedback or additional context. After each change, re-run `sdlc_pr` to update the PR description before final review.
 

--- a/src/sdlc/guides.py
+++ b/src/sdlc/guides.py
@@ -164,6 +164,56 @@ def list_roles(discovered: dict[tuple[str, str], Path]) -> list[str]:
     return sorted(stem for (kind, stem) in discovered if kind == "role")
 
 
+def globs_for_role(
+    role: str,
+    guide_map: dict[str, dict[str, list[str]]],
+) -> list[str]:
+    """Return the glob patterns scoping ``role`` under ``guide-map.role``.
+
+    This is the reverse of :func:`resolve_guides`: instead of mapping a path to
+    the stems whose patterns match it, it maps a role stem to every pattern that
+    lists it in the ``role`` namespace. A reviewer assigned ``role`` confines its
+    findings to files matching the returned patterns (any file may still be read
+    for context). Patterns preserve their order of appearance in the map and are
+    de-duplicated. Returns an empty list when no pattern maps to ``role``.
+    """
+    namespace = guide_map.get("role", {})
+    seen: set[str] = set()
+    result: list[str] = []
+    for pattern, stems in namespace.items():
+        if role in stems and pattern not in seen:
+            seen.add(pattern)
+            result.append(pattern)
+    return result
+
+
+def files_for_role(
+    paths: list[str],
+    role: str,
+    guide_map: dict[str, dict[str, list[str]]],
+) -> list[str]:
+    """Return the subset of ``paths`` scoped to ``role`` under ``guide-map.role``.
+
+    Composes :func:`globs_for_role` (the role-to-globs reverse lookup over the
+    already-merged ``guide-map.role``) with the same ``PurePath.full_match``
+    matching :func:`resolve_guides` uses, so a reviewer's in-scope file set is
+    computed from ground truth rather than re-derived from prose. A path is
+    in scope when it matches any glob mapped to ``role``. Input order is
+    preserved and paths are de-duplicated. Returns an empty list when no glob
+    maps to ``role`` or no path matches.
+    """
+    patterns = globs_for_role(role, guide_map)
+    seen: set[str] = set()
+    result: list[str] = []
+    for path in paths:
+        if path in seen:
+            continue
+        if any(PurePath(path).full_match(pattern) for pattern in patterns):
+            seen.add(path)
+            result.append(path)
+    return result
+
+
 def load_state(
     cwd: Path | None = None,
     package_dir: Path | None = None,

--- a/src/sdlc/pr_state.py
+++ b/src/sdlc/pr_state.py
@@ -1,8 +1,9 @@
-"""GitHub PR state detection for the `sdlc_implement` MCP endpoint."""
+"""GitHub PR state helpers for the ``sdlc_implement`` and ``sdlc_review`` MCP endpoints."""
 
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from dataclasses import dataclass
 from typing import Literal
@@ -81,6 +82,19 @@ _GRAPHQL_REVIEW_THREADS = (
     "{ nodes { body path line author { login } } } } } } } }"
 )
 
+_GRAPHQL_CLOSING_ISSUES = (
+    "query($owner: String!, $repo: String!, $pr: Int!) "
+    "{ repository(owner: $owner, name: $repo) { pullRequest(number: $pr) "
+    "{ closingIssuesReferences(first: 10) { nodes { number } } } } }"
+)
+
+# Closing keywords GitHub honors in a PR body: close/closes/closed,
+# fix/fixes/fixed, resolve/resolves/resolved — each followed by `#<number>`.
+_CLOSING_KEYWORD = re.compile(
+    r"\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s+#(\d+)",
+    re.IGNORECASE,
+)
+
 
 def _run_gh(args: list[str], allow_failure: bool = False) -> str | None:
     """Invoke ``gh`` and return stdout.
@@ -152,6 +166,45 @@ def _find_linked_pr(repo: _Repo, issue_number: int) -> dict | None:
     if not stripped or stripped == "null":
         return None
     return json.loads(stripped)
+
+
+def _find_closing_issue(repo: _Repo, pr_number: int) -> int | None:
+    """Return the issue number PR ``pr_number`` closes, or ``None``.
+
+    Queries GitHub's ``closingIssuesReferences`` connection — the authoritative
+    set of issues that close when the PR merges, regardless of whether they were
+    linked via a ``Closes #N`` keyword or through the GitHub UI. This is the
+    correct relationship check: it is deterministic and does not depend on
+    parsing prose. Falls back to scanning the PR body for a
+    ``Closes`` / ``Fixes`` / ``Resolves #N`` keyword only when the connection is
+    empty, and returns ``None`` when neither surface yields a linked issue.
+    """
+    graphql_args = [
+        "api", "graphql",
+        "-f", f"query={_GRAPHQL_CLOSING_ISSUES}",
+        "-f", f"owner={repo.owner}",
+        "-f", f"repo={repo.name}",
+        "-F", f"pr={pr_number}",
+    ]
+    graphql_out = _run_gh(graphql_args)
+    nodes = (
+        json.loads(graphql_out)
+        .get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("closingIssuesReferences", {})
+        .get("nodes", [])
+    )
+    if nodes:
+        return int(nodes[0]["number"])
+
+    body_args = _with_repo(["pr", "view", str(pr_number)], repo.repo_flag)
+    body_args += ["--json", "body", "--jq", ".body"]
+    body = _run_gh(body_args) or ""
+    match = _CLOSING_KEYWORD.search(body)
+    if match:
+        return int(match.group(1))
+    return None
 
 
 def _query_review_state(
@@ -245,3 +298,16 @@ def dispatch(number: int) -> Findings | PrContext | None:
     return Findings(
         pr_number=pr_number, head_ref=head_ref, url=url, findings=findings
     )
+
+
+def closing_issue(pr_number: int) -> int | None:
+    """Resolve the issue that PR ``pr_number`` closes.
+
+    Resolves the target repository (routing to upstream when the current repo is
+    a fork), then performs the ``closingIssuesReferences`` relationship check
+    with a PR-body keyword fallback. Returns the linked issue number, or ``None``
+    when the PR has no linked issue. Raises ``GhUnavailable`` when ``gh`` is
+    missing, unauthenticated, or errors.
+    """
+    repo = _resolve_repo()
+    return _find_closing_issue(repo, pr_number)

--- a/src/sdlc/review-template.md
+++ b/src/sdlc/review-template.md
@@ -1,0 +1,70 @@
+# PR #<N> — Round <iteration> Review
+
+Generated from a `<reviewers-per-role>`-reviewer review of PR #<N> (`<head-ref>` → `<base-ref>`, Closes #<issue>) at HEAD `<sha>`. Composition: `<reviewers-per-role>` reviewer(s) per role across role(s) `<role-a>`, `<role-b>`, … (`<reviewers-per-role> × <role-count>` reviewer subagents total). Findings are deduped within each role, merged across roles, and grouped by severity tier (blocking first). Each role's findings are confined to the files mapped to it in `guide-map.role`; any file may be read for context. Note for each role which globs scoped it and which files in this PR fell in scope.
+
+**Dedup approach** — Within a role, the consolidator collapses findings that name the same defect at the same reference into one (recording the reviewer agreement count, e.g. `4/5 reviewers`). Across roles, findings about the same defect are merged into a single entry that records every role that raised it; the entry takes the **highest** severity any role assigned, and dissent (a role that rated it lower, or did not raise it) is noted inline.
+
+**Severity legend** (the raising role's blocking policy is authoritative; the MUST/SHALL gloss is one example, not the definition) — **Blocking**: a defect that MUST be resolved before the PR can be approved per the raising role's blocking policy (for example, a violation of a MUST / SHALL guide rule, or a correctness defect on a consequential path). **Advisory**: clarity, consistency, or quality observations that do not gate approval per that policy (for example, SHOULD / MAY observations or optional improvements).
+
+**Branch commit map (for fixup mapping):**
+- `<sha>` — `<conventional-commit subject>` (`<touched files>`)
+- `<sha>` — `<conventional-commit subject>` (`<touched files>`)
+- …
+
+---
+
+## Tier 1 — Blocking
+
+### B1 — <one-line finding title> **(BLOCKING)** — <role(s) / reviewer agreement>
+**Reference:** `<file>:<line>` — use `file:line` when a single changed line applies; otherwise a file-level reference (`<file>`) or an issue-level one (`(cross-cutting — no single line)` / `issue acceptance criterion #<n>`) for omissions and diff-spanning concerns that have no single line.
+
+**Issue:** <What is wrong and why it matters. State the evidence concretely — quote the offending text or name the exact symbol — and tie it to the guide rule, correctness property, or role lens it violates. If roles disagreed on severity, say so here and explain the dissent.>
+
+**Remediation:**
+- [x] <The recommended fix, pre-selected by the consolidator.> *(Recommended — <one-clause rationale>.)*
+- [ ] <An alternative fix, if one is reasonable.>
+- [ ] Other: ________________________________________________
+
+**Tests to add:** <Optional — the test(s) that would catch a regression of this finding. Omit the whole line when none apply.>
+
+**Touched commit:** `<sha>`
+
+---
+
+### B2 — <one-line finding title> **(BLOCKING)** — <role(s) / reviewer agreement>
+**Reference:** `<file>:<line>` *(or `<file>` / `(cross-cutting — no single line)` / `issue acceptance criterion #<n>` for a line-less finding)*
+
+**Issue:** <…>
+
+**Remediation:**
+- [x] <Recommended fix.> *(Recommended — <rationale>.)*
+- [ ] <Alternative.>
+- [ ] Other: ________________________________________________
+
+**Touched commit:** `<sha>`
+
+---
+
+## Tier 2 — Advisory
+
+### A1 — <one-line finding title> — <role(s) / reviewer agreement>
+**Reference:** `<file>:<line>` *(or `<file>` / `(cross-cutting — no single line)` / `issue acceptance criterion #<n>` for a line-less finding)*
+
+<Concise statement of the advisory observation and the lens it comes from.>
+- [x] <Recommended fix.> *(Recommended — <rationale>.)*
+- [ ] Other: ________________________________________________
+
+**Touched commit:** `<sha>`
+
+---
+
+## Cross-cutting decisions
+
+<Themes that span multiple findings or a single root cause behind several of them — e.g. a doc-vs-reality mismatch repeated across files, an architectural choice that several findings orbit, or a tension between two roles' lenses that the consolidator resolved a particular way. Record the resolution and its rationale so the fixup pass applies it uniformly. Omit this section if there are no cross-cutting themes.>
+
+## Fixup mapping
+
+<For each blocking finding (and any advisory the user elects to fix), the commit its remediation should be folded into, so the fixup pass can `git commit --fixup=<sha>` against the right target. Group findings by the commit they touch.>
+
+- `<sha>` (`<conventional-commit subject>`) — B1, B2, A1
+- `<sha>` (`<conventional-commit subject>`) — B3

--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -11,6 +11,7 @@ PACKAGE_DIR = Path(__file__).resolve().parent
 SKILLS_DIR = PACKAGE_DIR / "skills"
 AGENTS_MD_PATH = PACKAGE_DIR / "AGENTS.md"
 ROLE_TEMPLATE_PATH = PACKAGE_DIR / "role-template.md"
+REVIEW_TEMPLATE_PATH = PACKAGE_DIR / "review-template.md"
 
 _state = guides.load_state(cwd=Path.cwd(), package_dir=PACKAGE_DIR)
 
@@ -181,18 +182,59 @@ async def sdlc_pr(issue_number: int, target: str | None = None) -> str:
 
 
 @mcp.tool()
-async def sdlc_review(pr_number: int) -> str:
-    """Review an open pull request for compliance and quality.
+async def sdlc_review(
+    pr_number: int,
+    roles: list[str] | None = None,
+    subagents: int = 1,
+) -> str:
+    """Review an open pull request and produce a local consolidated document.
 
     Use when the user says "review", "review PR #N", "review this PR",
-    or similar. Analyzes the PR diff against project guides, categorizes
-    findings by severity, and posts an inline review.
+    or similar. Spawns `subagents` reviewer(s) per role across `roles`
+    (`subagents × len(roles)` reviewer subagents total), each reviewing the
+    diff through its role's lens and confined to that role's `guide-map.role`
+    files. The main session agent consolidates their findings into a single
+    `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. Nothing is posted to
+    GitHub. The linked issue `<N>` is resolved here via the
+    `closingIssuesReferences` relationship (with a PR-body fallback) and
+    supplied to the skill.
 
     Args:
         pr_number: The PR number to review.
+        roles: Review-role stems to run, one reviewer set per role. Defaults
+            to ["general-purpose"] when omitted.
+        subagents: Number of independent reviewers to run per role. Defaults
+            to 1.
     """
+    if roles is None:
+        roles = ["general-purpose"]
     skill = _read_skill("review")
-    return f"{skill}\n---\n\nTarget PR: #{pr_number}"
+    template = _read_file(REVIEW_TEMPLATE_PATH)
+    roles_line = ", ".join(roles)
+    try:
+        issue_number = pr_state.closing_issue(pr_number)
+    except pr_state.GhUnavailable:
+        issue_number = None
+    if issue_number is not None:
+        issue_line = (
+            f"Resolved issue: #{issue_number}\n"
+            f"Review document directory: .sdlc/reviews/issue-#{issue_number}/"
+        )
+    else:
+        issue_line = (
+            "Resolved issue: unresolved -- the PR has no linked issue via the "
+            "closingIssuesReferences relationship or a Closes/Fixes/Resolves "
+            "keyword; ask the user which issue it addresses before writing the "
+            "review document."
+        )
+    return (
+        f"{skill}\n---\n\n"
+        f"Target PR: #{pr_number}\n"
+        f"Roles: {roles_line}\n"
+        f"Reviewers per role: {subagents}\n"
+        f"{issue_line}\n\n"
+        f"Review document template:\n\n{template}"
+    )
 
 
 @mcp.tool()
@@ -238,6 +280,29 @@ async def sdlc_roles() -> list[str]:
     return [
         f"sdlc://guides/role/{stem}" for stem in guides.list_roles(_state.discovered)
     ]
+
+
+@mcp.tool()
+async def sdlc_role_scope(paths: list[str], role: str) -> list[str]:
+    """Return the subset of `paths` a role's findings are confined to.
+
+    Performs the reverse lookup over the server's already-merged
+    `guide-map.role` (default config deep-merged with `.sdlc/config.json`) and
+    intersects the role's globs with `paths` using the same
+    `pathlib.PurePath.full_match` semantics `sdlc_guides_for` uses. The
+    `sdlc_review` skill calls this to scope each reviewer to its role's files
+    instead of re-deriving the merge and glob match by hand. An empty list
+    means the role maps to none of the given paths (a role with no
+    `guide-map.role` entry, or a real role whose globs match no changed file);
+    callers MUST distinguish those cases (see the review skill). The bundled
+    `general-purpose` role maps to `**/*`, so every path is in scope.
+
+    Args:
+        paths: File paths (relative to project root) to scope — typically the
+            PR's changed files.
+        role: The review-role stem to scope `paths` for.
+    """
+    return guides.files_for_role(paths, role, _state.guide_map)
 
 
 @mcp.tool()
@@ -288,6 +353,12 @@ async def get_default_config() -> str:
 async def role_template() -> str:
     """Return the bundled role-document template."""
     return _read_file(ROLE_TEMPLATE_PATH)
+
+
+@mcp.resource("sdlc://review-template")
+async def review_template() -> str:
+    """Return the bundled consolidated-review-document template."""
+    return _read_file(REVIEW_TEMPLATE_PATH)
 
 
 @mcp.resource("sdlc://agents-md")

--- a/src/sdlc/skills/review.md
+++ b/src/sdlc/skills/review.md
@@ -3,14 +3,15 @@ name: review
 description: >
   Review an open pull request for guide compliance, correctness, and code
   quality. Use this skill whenever the user says "review", "review PR #N",
-  "review this PR", or similar. Fetches the PR diff and metadata, reads the
-  project guides and source files under review, analyzes findings by severity,
-  presents them for approval, and posts an inline review via the GitHub API.
+  "review this PR", or similar. Fetches the PR diff and metadata, runs one or
+  more reviewer subagents per role (each confined to its role's mapped files),
+  consolidates their findings into a single standardized local document under
+  `.sdlc/reviews/`, and presents it. Does not post to GitHub.
 subagent:
   support: optional
   type: general-purpose
   artifacts:
-    - review_event_posted
+    - review_document_path
     - findings_count
     - pr_number
 ---
@@ -19,27 +20,46 @@ The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RE
 
 # Review Skill
 
-Fetch a pull request, analyze its diff against project guides and source context, categorize findings by severity, present them for user approval, and post an inline GitHub review.
+Fetch a pull request, review its diff through one or more role lenses (N reviewers per role), consolidate the findings into a single standardized local review document under `.sdlc/reviews/`, and present it for the user to drive fixups. This skill writes a local document; it does NOT post to GitHub.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **sixth** stage, invoked after the PR has been created and is ready for review.
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **sixth** stage, invoked after the PR has been created and is ready for review. Its output — the consolidated review document — is a local artifact under `.sdlc/reviews/` that you and the user read manually to drive fixups. It is NOT auto-consumed by the `implement` skill, and because nothing is posted to GitHub, a later `sdlc_implement` call routes to `implement-continue` (not `implement-feedback`) unless the user separately surfaces the findings.
+
+## Composition
+
+A review runs through one or more **roles**, with N **reviewers per role**. The arguments appended below this prompt supply the role list and the per-role reviewer count:
+
+- **Roles** — the role stems to review through (default: a single `general-purpose` role). Each role is a named lens with a blocking policy, discoverable via `sdlc_roles` and readable at `sdlc://guides/role/<stem>`.
+- **Reviewers per role** — N independent reviewer subagents per role (default: 1).
+
+The total number of reviewer subagents is **N × (number of roles)**. Each reviewer reviews the same diff but through exactly one assigned role's lens, confined to the files that role is mapped to, and returns structured findings. The main session agent then consolidates all reviewers' findings into the single review document. A reviewer NEVER writes a file or posts anything — it only returns findings.
 
 ## Invariants
 
-- MUST NOT post the review until the user explicitly approves the final set of findings.
-- MUST use `REQUEST_CHANGES` as the review event when any blocking findings remain after approval.
-- MUST present every finding to the user with severity, file, line range, and comment text before posting.
+- MUST NOT post anything to GitHub. This skill produces a local document only — there is no `gh api .../reviews` call, no review event, and no inline comments.
+- When the review proceeds to completion, MUST write exactly one consolidated document per invocation, at `.sdlc/reviews/issue-#<N>/review-<iteration>.md`, where `<N>` is the resolved linked issue and `<iteration>` is the 1-based next iteration. The unresolved-issue branch (the PR has no linked issue) and the declined-large-diff branch may end without writing a document — no document is written when the run does not reach completion on those paths.
+- MUST NOT write the document until the user has approved the consolidated findings, exactly as presented.
+- Each reviewer's findings MUST be confined to the files mapped to its role in `guide-map.role` (any file MAY be read for context). The default `general-purpose` role is mapped to `**/*`, so its findings span the whole diff.
+- When consolidating, each finding MUST be assigned the **highest** severity any role gives it; where roles disagree, the dissent MUST be noted on the finding.
+- For each finding, the consolidator MUST pre-select the recommended remediation option with `[x]`, list any alternatives with `[ ]`, and always include an `Other: ___` slot.
 - MUST NOT fabricate guide requirements that do not exist in the project's actual guides.
 - MUST use the `understand-chat` skill to query the knowledge graph for context gathering when `.understand-anything/knowledge-graph.json` exists.
 
 ## Arguments
 
-A PR number MUST be provided as the sole argument (e.g., `review` with PR #146).
+The MCP endpoint appends the following below this skill prompt:
+
+- `Target PR: #<pr-number>` — the PR to review.
+- `Roles: <role-a>, <role-b>, …` — the role stems to review through (defaults to `general-purpose`).
+- `Reviewers per role: <N>` — how many independent reviewers to run per role (defaults to 1).
+- `Resolved issue: #<N>` — the linked issue resolved by the endpoint via the `closingIssuesReferences` relationship (or an `unresolved` notice when the PR has no linked issue). Defines the `.sdlc/reviews/issue-#<N>/` path.
+- `Review document directory: .sdlc/reviews/issue-#<N>/` — the directory holding this PR's review rounds.
+- The bundled review-document template (also available as the `sdlc://review-template` resource), which defines the exact structure of the document to write.
 
 ## Subagent Execution (Optional)
 
-This skill MAY be executed in an isolated subagent to preserve parent context. When invoked with a `--subagent` flag, execute according to your tool:
+This skill MAY itself be executed in an isolated orchestrator subagent to preserve parent context (distinct from the per-role reviewer subagents this skill spawns internally). When invoked with a `--subagent` flag, execute according to your tool:
 
 **Claude Code:**
 - MUST spawn a general-purpose subagent using the Agent tool with this brief:
@@ -47,7 +67,7 @@ This skill MAY be executed in an isolated subagent to preserve parent context. W
   > 1. Read the project instructions in `AGENTS.md`
   > 2. Read and execute the complete workflow defined in this skill's markdown
   > 3. Follow every step faithfully, especially the Invariants section
-  > 4. Return a structured summary: accomplishments, key artifacts (review event posted, findings count, PR number), and the next pipeline step prompt from the skill
+  > 4. Return a structured summary: accomplishments, key artifacts (review document path, findings count, PR number), and the next pipeline step prompt from the skill
 
 - When the subagent returns, reproduce its full output to the user exactly as written — do not summarize, condense, paraphrase, or omit sections. The user needs to review the complete output to give informed approval. Do not repeat work or add your own commentary.
 
@@ -59,15 +79,16 @@ This skill MAY be executed in an isolated subagent to preserve parent context. W
 ### Checklist
 
 1. Resolve target repository
-2. Fetch the PR metadata and diff
-3. Read project guides and styles
-4. Read source files under review
-5. Gather knowledge graph context
-6. Analyze the diff
-7. Categorize findings
-8. Present findings for approval
-9. Post the review
-10. Prompt the user with next steps
+2. Fetch the PR metadata, diff, and commit map
+3. Resolve the review-document path
+4. Read project guides and styles
+5. Resolve each role's lens and mapped files
+6. Gather knowledge graph context
+7. Dispatch reviewer subagents (N per role)
+8. Consolidate the findings
+9. Present the consolidated document for approval
+10. Write the review document
+11. Prompt the user with next steps
 
 ### 1. Resolve target repository
 
@@ -75,22 +96,54 @@ This skill MAY be executed in an isolated subagent to preserve parent context. W
 gh repo view --json isFork,parent
 ```
 
-If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. Also extract the `<owner>` and `<repo>` values separately — these are needed for the GitHub API call in step 8. If the repo is not a fork, the target repo is the current repo, `<owner>` and `<repo>` are derived from the current repo, and no `--repo` flag is needed.
+If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form the upstream repo identifier (`<owner>/<name>`). This upstream identifier becomes the **target repo** for all subsequent `gh` commands that reference issues or pull requests. If the repo is not a fork, the target repo is the current repo and no `--repo` flag is needed.
 
 **User override:** If the user explicitly asks to target the fork — by saying "fork", "on the fork", "fork #N", or similar — the target repo MUST be set to the current (fork) repo instead of upstream. The user's explicit intent always takes precedence.
 
 All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
 
-### 2. Fetch the PR metadata and diff
+### 2. Fetch the PR metadata, diff, and commit map
 
 ```bash
-gh pr view <number> --repo <target> --json title,body,headRefName,baseRefName,changedFiles
+gh pr view <number> --repo <target> --json title,body,headRefName,baseRefName,changedFiles,headRefOid
 gh pr diff <number> --repo <target>
 ```
 
-If the PR does not exist, inform the user and stop. Parse the PR title, body, branch names, and the list of changed files. The `--repo <target>` flag ensures commands operate against the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
+If the PR does not exist, inform the user and stop. Parse the PR title, body, branch names, the list of changed files, and `headRefOid` (the target HEAD sha recorded in the document header). The `--repo <target>` flag ensures commands operate against the upstream repo when working from a fork (as resolved in step 1). If the target repo is the current repo, the flag MAY be omitted.
 
-### 3. Read project guides and styles
+**Capture the diff text** returned by `gh pr diff` — this exact text is interpolated into each reviewer's brief in step 7 (the reviewers are spawned into fresh contexts and do NOT inherit this read).
+
+**Verify the local working tree is at the PR head.** The diff above comes from the remote, but reviewers read the changed files from the local filesystem, so the recorded `headRefOid` and the lines they read must correspond:
+
+```bash
+git rev-parse HEAD
+```
+
+If `HEAD` does not equal `headRefOid`, the local tree is not on the PR head (stale branch, different worktree, or dirty tree) and the `file:line` references would be off. Fetch and check out the PR head (`gh pr checkout <number> --repo <target>`, or `git fetch` + checkout of `headRefOid`), or — if you cannot or the user declines — warn the user that the recorded `<sha>` assumes the working tree is at the PR head and that references may drift.
+
+**Build the branch commit map.** The header commit map, each finding's `Touched commit`, and the fixup mapping all need each commit's sha, conventional-commit subject, and touched files. No earlier step supplies these, so enumerate them now from the PR's commit range:
+
+```bash
+git log <baseRefName>..<headRefName> --name-only --pretty=format:'%h %s'
+```
+
+(or `gh pr view <number> --repo <target> --json commits` combined with the `--name-only` log). This yields the per-commit `(<sha>, <conventional-commit subject>, <touched files>)` tuples. Hold this **branch commit map** for use in step 8: it fills the header commit map, attributes each finding's `file:line` to the commit that owns that file, and builds the fixup mapping. Do NOT improvise shas — derive them from this command.
+
+### 3. Resolve the review-document path
+
+The document lives at `.sdlc/reviews/issue-#<N>/review-<iteration>.md`.
+
+**`<N>` — the linked issue — is resolved for you.** The MCP endpoint performs the relationship check via GitHub's `closingIssuesReferences` connection (issues that close when the PR merges, whether linked via a `Closes #N` keyword or the GitHub UI), with a `Closes` / `Fixes` / `Resolves #N` PR-body fallback. When several issues are linked, the endpoint resolves the **first** of them (the connection has no ordering guarantee), so `<N>` is one closing issue, not necessarily the only one. It appends the result below this prompt as `Resolved issue: #<N>`, together with the `Review document directory`. Use the provided `<N>` directly; do NOT re-derive it. If you can tell the PR closes more than one issue, surface a note to the user confirming the chosen `issue-#<N>/` directory before writing. If the appended directive reports the issue as **unresolved** (the PR has no linked issue), ask the user which issue the PR addresses before proceeding; do NOT guess the path.
+
+**Resolve `<iteration>` — the 1-based review round.** Inspect the issue's review directory for existing rounds:
+
+```bash
+ls .sdlc/reviews/issue-#<N>/review-*.md 2>/dev/null
+```
+
+`<iteration>` is one greater than the highest `<n>` among existing `review-<n>.md` files. If the directory does not exist or contains no `review-*.md`, `<iteration>` is `1`. The target document path is therefore `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. Do NOT create the directory or file yet — that happens in step 10, after approval.
+
+### 4. Read project guides and styles
 
 MUST read the following files to establish the review baseline:
 
@@ -100,14 +153,18 @@ MUST read the following files to establish the review baseline:
 
 Only the guides relevant to the changed files are returned by the resolver — no manual filtering required. If `sdlc_guides_for` returns an empty list for a kind, no guide of that kind applies to the diff.
 
-### 4. Read source files under review
+### 5. Resolve each role's lens and mapped files
 
-For each changed file in the PR:
+**Validate the role list first.** Call `sdlc_roles` to list the discovered roles. Every supplied role stem MUST appear among them. If a stem is not a discovered role — or if reading its document at `sdlc://guides/role/<stem>` returns a string beginning with `Error: guide ... not found` — the role does not exist (likely a typo). In that case you MUST stop and ask the user to correct the role name; do NOT brief a reviewer with the error text as its lens. (`sdlc://config/default` is the unmerged package default; do not treat it as the live merged map.)
 
-- MUST read the full file at its current HEAD revision so that surrounding context is available.
-- If the changed file is a test file, MUST also read the corresponding source module it tests (and vice versa).
+For every validated role in the role list:
 
-### 5. Gather knowledge graph context
+- Read the role document at `sdlc://guides/role/<stem>` to obtain its **lens / identity** and **blocking policy**.
+- Determine the **files the role's findings are confined to** by calling `sdlc_role_scope(<the PR's changed files>, "<stem>")`. This returns the changed files in scope for the role — it performs the `guide-map.role` reverse lookup over the server's already-merged config (default deep-merged with `.sdlc/config.json`) and applies the `pathlib.PurePath.full_match` matching for you, so you do NOT re-derive the merge or the glob match by hand. The default `general-purpose` role maps to `**/*`, so every changed file is in scope.
+
+Distinguish the two empty-scope cases: an empty result for a **discovered** role means it maps to none of this PR's changed files (it has nothing to review here — note it in the header and skip dispatching reviewers for it). A role with **no `guide-map.role` entry at all** also returns empty; warn the user it will contribute nothing before skipping it. (An unknown / misspelled stem was already rejected by the validation above.)
+
+### 6. Gather knowledge graph context
 
 MUST check whether a knowledge graph exists:
 
@@ -115,98 +172,72 @@ MUST check whether a knowledge graph exists:
 test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
 ```
 
-If the graph exists, MUST use the `understand-chat` skill with a query listing the changed file paths from the PR diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals how changed components fit into the broader architecture and informs review quality. If the graph does not exist, skip this step and continue.
+If the graph exists, MUST use the `understand-chat` skill with a query listing the changed file paths from the PR diff to gather architectural context — component summaries, relationships, and layer assignments — that reveals how changed components fit into the broader architecture and informs review quality. If the graph does not exist, skip this step and continue. When a graph exists, pass the resulting summary to the reviewer subagents via the optional architectural-context slot in the step-7 brief (the reviewers do NOT inherit this `understand-chat` output otherwise); omit that slot when no graph exists.
 
-### 6. Analyze the diff
+### 7. Dispatch reviewer subagents (N per role)
 
-Review every hunk in the diff against the guides read in step 3 and the source context read in step 4. Check for:
+For each role, spawn **N independent reviewer subagents** (N = reviewers per role). A reviewer reviews the diff through exactly one role's lens and returns structured findings — it MUST NOT write any file or post anything.
 
-- **Guide compliance** — violations of MUST/SHALL/SHOULD rules from `AGENTS.md`, the test guide, and style guides. Cite the specific guide rule being violated.
-- **Naming and conventions** — inconsistent naming, style drift from the surrounding codebase, or departures from documented conventions.
-- **Coverage regressions** — new public APIs without corresponding tests, removed tests without justification, or test gaps relative to the PR's own test cases table.
-- **Correctness bugs** — logic errors, race conditions, missing error handling at system boundaries, incorrect use of APIs or libraries.
-- **Code quality** — unnecessary complexity, dead code, duplicated logic, or poor separation of concerns.
+**Claude Code:** Spawn each reviewer using the Agent tool. Run all reviewers concurrently where the tool allows. A reviewer is spawned into a fresh, isolated context: it inherits none of your reads, so every input it needs MUST be interpolated into its brief (replace each `<…>` placeholder with the actual value before spawning). Each reviewer's brief MUST include:
 
-Each finding MUST reference the specific file and line range in the diff where the issue occurs.
+> You are a **reviewer** for the SDLC `review` skill, assigned the **`<role-stem>`** role.
+> - Your lens and blocking policy: `<the role document body>`.
+> - Your findings are confined to these files (matched from `guide-map.role`): `<the role's in-scope changed files>`. You MAY read any other file for context, but raise findings ONLY against your in-scope files.
+> - Apply your role's blocking policy to classify each finding as **Blocking** or **Advisory**.
+> - The PR diff under review (full text): `<pr-diff>` — the `gh pr diff` output captured in step 2. Review THIS diff; do not infer the diff from whatever branch or working tree you happen to be on.
+> - The project guides to review against (full text): `<AGENTS.md body + the body of each resolved test and style guide from step 4>`. Cite guide rules only from this text — do NOT fabricate requirements that are not in it.
+> - Architectural context for the changed files (when a knowledge graph exists): `<the understand-chat summary from step 6>`. *(Omit this bullet entirely when no knowledge graph exists.)*
+> - Read each in-scope changed file from the local checkout, which is at the PR head `<sha>` (the orchestrator verified this in step 2); if a changed file is a test, also read the module it tests (and vice versa).
+> - Investigate through your assigned lens: apply the focus areas your role's lens / blocking policy defines above. **Only** when your role is `general-purpose` (or its document does not enumerate its own focus) fall back to the generic checklist: guide compliance (cite the specific MUST / SHALL / SHOULD rule), naming and convention drift, coverage regressions (new public APIs without tests, removed tests without justification), correctness bugs (logic errors, race conditions, missing error handling at boundaries, incorrect API use), and code quality (unnecessary complexity, dead code, duplicated logic). Do not pull yourself off your lens to chase items the generic list names but your role does not.
+> - Return **structured findings only** — for each: a short title, severity, a reference, the issue with concrete evidence, a recommended remediation (and any alternatives), and optional tests-to-add. The reference is `file:line` when a single changed line applies; otherwise use a file-level reference (`<file>`) or an issue-level one (`(cross-cutting — no single line)` / `issue acceptance criterion #<n>`). Issue-level omissions (something the PR missed) and diff-spanning architectural concerns are first-class findings even without a line — raise them. Do NOT attribute a commit sha (the orchestrator owns commit attribution in step 8). Do NOT write a file, do NOT post to GitHub, do NOT consolidate — return your raw findings to the orchestrator.
 
-### 7. Categorize findings
+**Other LLM assistants:** If subagents are unavailable, perform each role's review inline, one role at a time, holding each role's findings separately so they can be consolidated in step 8.
 
-Every finding MUST be assigned exactly one severity:
+### 8. Consolidate the findings
 
-- **Blocking** — Violations of MUST or SHALL requirements from any project guide. These MUST be resolved before the PR can be approved.
-- **Non-blocking** — Violations of SHOULD or RECOMMENDED requirements, style suggestions, or minor quality improvements. These are advisory and do not block approval.
+The main session agent (NOT a reviewer) merges every reviewer's findings into one set:
 
-Present findings grouped by severity, with blocking findings first.
+- **Dedup within a role** — collapse findings from the same role that name the same defect at the same reference into a single finding, recording the reviewer agreement (e.g. `4/5 reviewers`).
+- **Merge across roles** — combine findings about the same defect raised by different roles into one entry that records every role that raised it.
+- **Highest severity wins** — assign each finding the highest severity any role gave it. Where roles disagree (one rated it Blocking, another Advisory or did not raise it), NOTE the dissent on the finding.
+- **Assign stable IDs** — `B1, B2, …` for blocking findings, `A1, A2, …` for advisory, in a stable order.
+- **Pre-select remediation** — for each finding, choose the recommended remediation and mark it `[x]`, list reasonable alternatives as `[ ]`, and always append an `Other: ___` slot.
+- **Group by severity tier, blocking first** — Tier 1 (Blocking) then Tier 2 (Advisory).
+- **Attribute each finding to a commit** — using the **branch commit map** built in step 2, match each finding's `file:line` (or file-level reference) against the commit that touched that file to set its `Touched commit`. The consolidator owns this attribution; do not rely on any sha from a reviewer (the reviewers were told not to supply one). A finding with no single file (cross-cutting / issue-level) maps to the commit(s) most responsible, or is grouped under the relevant commit in the fixup mapping with a note.
+- Populate the document header (roles used, reviewers per role, target HEAD sha, dedup approach, severity legend, and the branch commit map from step 2), and fill the **cross-cutting decisions** and **fixup mapping** sections, following the bundled template appended below this prompt exactly.
 
-### 8. Present findings for approval
+Severity definitions (the raising role's blocking policy is authoritative — the MUST/SHALL gloss is one common example, not the definition, since a role's policy need not be phrased in MUST/SHALL terms):
 
-The complete list of findings MUST be presented to the user before posting. For each finding, show:
+- **Blocking** — a defect that MUST be resolved before the PR can be approved per the raising role's blocking policy (for example, a violation of a MUST / SHALL guide rule, or a correctness defect on a consequential path).
+- **Advisory** — clarity, consistency, or quality observations that do not gate approval per that policy (for example, SHOULD / MAY observations or optional improvements).
 
-- Severity (blocking / non-blocking)
-- File and line range
-- Description of the issue
-- The comment text that will be posted
+### 9. Present the consolidated document for approval
 
-The user MUST be given the opportunity to:
+Render the full consolidated document and present it to the user before writing anything. The user MUST be given the opportunity to:
 
 - **Remove** any finding they disagree with.
-- **Edit** the comment text of any finding.
-- **Add** new findings the agent missed.
-- **Change** the severity of any finding.
+- **Edit** the text, reference, or remediation options of any finding.
+- **Add** new findings the reviewers missed.
+- **Change** the severity of any finding (re-tiering it).
+- **Re-select** which remediation option is recommended.
 
-The review MUST NOT be posted until the user explicitly approves the final set of findings.
+The document MUST NOT be written until the user explicitly approves the final consolidated set, exactly as it will be written.
 
-### 9. Post the review
+### 10. Write the review document
 
-Construct a review payload and post it via the GitHub API. The payload MUST be written to a temporary file to avoid shell escaping issues:
+After approval, create the directory and write the document:
 
 ```bash
-cat > /tmp/review_payload.json << 'EOF'
-{
-  "event": "<APPROVE|REQUEST_CHANGES|COMMENT>",
-  "body": "",
-  "comments": [
-    {
-      "path": "relative/path/to/file.py",
-      "line": 42,
-      "body": "Comment text here."
-    }
-  ]
-}
-EOF
-gh api repos/<owner>/<repo>/pulls/<number>/reviews \
-  --method POST --input /tmp/review_payload.json
+mkdir -p .sdlc/reviews/issue-#<N>
 ```
 
-**Review event selection:**
+Write the approved consolidated document to `.sdlc/reviews/issue-#<N>/review-<iteration>.md`, following the bundled template structure exactly: the header, the severity-tiered findings (blocking first) with stable IDs / titles / severities / `Reference` (`file:line`, or a file-level / issue-level reference for a line-less finding) / Issue + evidence / Remediation checklist (`[x]` recommended, `[ ]` alternatives, `Other: ___`) / optional Tests-to-add / Touched commit, and the cross-cutting-decisions and fixup-mapping sections. Do NOT post anything to GitHub.
 
-- If there are any **blocking** findings remaining after user approval, the event MUST be `REQUEST_CHANGES`.
-- If there are only **non-blocking** findings, the event SHOULD be `COMMENT`.
-- If there are no findings, the event SHOULD be `APPROVE`.
+### 11. Prompt the user with next steps
 
-**Review body:** The top-level review `body` SHOULD be an empty string when all findings are line-specific inline comments. A non-empty body is acceptable for findings that cannot be associated with a specific changed line — for example, something from the issue that the PR completely missed, or an architectural concern that spans the entire diff. The user decides whether to use a top-level comment — defer to them.
+After the document is written, prompt the user:
 
-**Comment text:** Each inline comment MUST contain only the substantive feedback. Comments MUST NOT include pseudo-headers, severity labels, category tags, or other metadata — just the review feedback itself.
-
-**Multi-line comments:** When a finding spans multiple lines, use the `start_line` and `line` fields to highlight the full range:
-
-```json
-{
-  "path": "relative/path/to/file.py",
-  "start_line": 10,
-  "line": 15,
-  "body": "Comment text here."
-}
-```
-
-The `<owner>` and `<repo>` values MUST be resolved from step 1. When working from a fork, these refer to the upstream repo's owner and name (unless the user explicitly targeted the fork).
-
-### 10. Prompt the user with next steps
-
-After the review is posted, prompt the user with the appropriate next step:
-
-- If the review event was `REQUEST_CHANGES` or `COMMENT`: "Review posted. Address the findings with the `implement` skill and re-run the `review` skill after pushing fixes."
-- If the review event was `APPROVE`: "PR approved. Run `gh pr ready <number>` to mark it ready for merge."
+> Review written to `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. This document is a local artifact — nothing was posted to GitHub, and the `implement` skill does not read it automatically. Read it yourself (or with the user) and use each finding's pre-selected remediation and fixup-mapping entry as the work list, applying the fixups directly; then re-run `commit`, `pr`, and `review` as needed. When the findings are resolved and you are satisfied, run `gh pr ready <number>` to mark the PR ready for merge.
 
 DO NOT proceed on your own.
 
@@ -214,10 +245,18 @@ DO NOT proceed on your own.
 
 **PR is already merged or closed:** Inform the user that the PR is not open and stop.
 
-**No findings:** If the diff passes all checks cleanly, post an `APPROVE` review with an empty body and no inline comments. Inform the user that no issues were found.
+**No findings:** If every reviewer returns clean, present the empty-findings document (header plus empty severity tiers) for approval as in step 9, and only after the user approves, write it so the round is recorded; inform the user that no issues were found and the PR looks ready. The approval gate still applies on the clean path — do not write before approval. Do not post anything.
+
+**No linked issue (the endpoint reports `Resolved issue: unresolved`):** Ask the user which issue the PR addresses; do not guess the `.sdlc/reviews/issue-#<N>/` path.
+
+**Unknown / misspelled role:** A requested role with no discovered document (not among `sdlc_roles`, or whose `sdlc://guides/role/<stem>` read returns `Error: guide ... not found`) MUST halt the run with a corrective prompt asking the user to fix the role name. Do NOT dispatch a reviewer with an empty or error lens.
+
+**A role exists but has no `guide-map.role` entry:** `sdlc_role_scope` returns empty for it just as it does for an unmapped role. Warn the user the role will contribute nothing (it is not scoped to any files), then skip it.
+
+**A role maps to globs that match none of the changed files:** Note in the header that the discovered, mapped role had no in-scope files on this PR and skip its reviewers; it contributes no findings.
 
 **Binary files in diff:** Binary files MUST be skipped during analysis. Note their presence to the user but do not attempt to review them.
 
-**Very large diffs:** For PRs with more than 20 changed files or more than 1000 lines changed, the agent SHOULD summarize the scope to the user and ask whether to review the full diff or focus on specific files.
+**Very large diffs:** For PRs with more than 20 changed files or more than 1000 lines changed, the agent SHOULD summarize the scope to the user and ask whether to review the full diff or focus on specific files before dispatching reviewers.
 
 **Files outside the repository's guide coverage:** If changed files are in a language or domain not covered by any project guide, review them for general correctness and code quality only. Do not fabricate guide requirements that do not exist.

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -6,6 +6,8 @@ import pytest
 
 from sdlc.guides import (
     discover_guides,
+    files_for_role,
+    globs_for_role,
     list_roles,
     load_package_default,
     load_state,
@@ -1017,6 +1019,248 @@ def test_list_roles_should_return_empty_when_no_roles(tmp_path):
 
     # Assert
     assert result == []
+
+
+def test_globs_for_role_should_return_patterns_mapped_to_role():
+    """Test the reverse lookup returns every glob mapped to the role.
+
+    Given:
+        A guide-map.role mapping two globs to 'architect'.
+    When:
+        globs_for_role('architect', guide_map) is called.
+    Then:
+        Both globs are returned in map order.
+    """
+    # Arrange
+    guide_map = {
+        "role": {
+            "src/**/*.py": ["architect"],
+            "lib/**/*.py": ["architect"],
+        }
+    }
+
+    # Act
+    result = globs_for_role("architect", guide_map)
+
+    # Assert
+    assert result == ["src/**/*.py", "lib/**/*.py"]
+
+
+def test_globs_for_role_should_return_only_patterns_listing_the_role():
+    """Test the reverse lookup ignores globs that do not list the role.
+
+    Given:
+        A guide-map.role where one glob lists 'architect' and another lists
+        only 'security'.
+    When:
+        globs_for_role('architect', guide_map) is called.
+    Then:
+        Only the glob that lists 'architect' is returned.
+    """
+    # Arrange
+    guide_map = {
+        "role": {
+            "src/**/*.py": ["architect"],
+            "tests/**/*.py": ["security"],
+        }
+    }
+
+    # Act
+    result = globs_for_role("architect", guide_map)
+
+    # Assert
+    assert result == ["src/**/*.py"]
+
+
+def test_globs_for_role_should_match_role_among_multiple_stems():
+    """Test the reverse lookup matches a role sharing a glob with other roles.
+
+    Given:
+        A glob mapped to a list containing 'architect' alongside another role.
+    When:
+        globs_for_role('architect', guide_map) is called.
+    Then:
+        The shared glob is returned.
+    """
+    # Arrange
+    guide_map = {"role": {"src/**/*.py": ["architect", "security"]}}
+
+    # Act
+    result = globs_for_role("architect", guide_map)
+
+    # Assert
+    assert result == ["src/**/*.py"]
+
+
+def test_globs_for_role_should_return_empty_when_role_unmapped():
+    """Test the reverse lookup returns an empty list for an unmapped role.
+
+    Given:
+        A guide-map.role with no glob listing the requested role.
+    When:
+        globs_for_role('ghost', guide_map) is called.
+    Then:
+        An empty list is returned.
+    """
+    # Arrange
+    guide_map = {"role": {"src/**/*.py": ["architect"]}}
+
+    # Act
+    result = globs_for_role("ghost", guide_map)
+
+    # Assert
+    assert result == []
+
+
+def test_globs_for_role_should_return_empty_when_role_namespace_absent():
+    """Test the reverse lookup returns an empty list when no role namespace exists.
+
+    Given:
+        A guide-map with only test and style namespaces.
+    When:
+        globs_for_role('architect', guide_map) is called.
+    Then:
+        An empty list is returned.
+    """
+    # Arrange
+    guide_map = {"test": {"**/*.py": ["python"]}}
+
+    # Act
+    result = globs_for_role("architect", guide_map)
+
+    # Assert
+    assert result == []
+
+
+def test_globs_for_role_should_return_whole_diff_glob_for_general_purpose():
+    """Test the bundled general-purpose role maps to the whole-diff glob.
+
+    Given:
+        The shipped default config's guide-map.
+    When:
+        globs_for_role('general-purpose', guide_map) is called for the default map.
+    Then:
+        The '**/*' whole-diff glob is returned.
+    """
+    # Arrange
+    guide_map = load_package_default()["guide-map"]
+
+    # Act
+    result = globs_for_role("general-purpose", guide_map)
+
+    # Assert
+    assert result == ["**/*"]
+
+
+def test_files_for_role_should_return_paths_matching_the_role_globs():
+    """Test the scope lookup returns only paths matching the role's globs.
+
+    Given:
+        A guide-map.role mapping 'src/**/*.py' to 'architect' and a mix of
+        in-scope and out-of-scope paths.
+    When:
+        files_for_role(paths, 'architect', guide_map) is called.
+    Then:
+        Only the paths under src/ that match the glob are returned.
+    """
+    # Arrange
+    guide_map = {"role": {"src/**/*.py": ["architect"]}}
+    paths = ["src/foo.py", "tests/bar.py", "README.md"]
+
+    # Act
+    result = files_for_role(paths, "architect", guide_map)
+
+    # Assert
+    assert result == ["src/foo.py"]
+
+
+def test_files_for_role_should_union_matches_across_multiple_globs():
+    """Test the scope lookup unions matches from every glob mapped to the role.
+
+    Given:
+        Two globs both mapped to 'architect' and paths matching each.
+    When:
+        files_for_role(paths, 'architect', guide_map) is called.
+    Then:
+        Paths matching either glob are returned, in input order.
+    """
+    # Arrange
+    guide_map = {
+        "role": {
+            "src/**/*.py": ["architect"],
+            "lib/**/*.py": ["architect"],
+        }
+    }
+    paths = ["src/foo.py", "lib/bar.py", "docs/x.md"]
+
+    # Act
+    result = files_for_role(paths, "architect", guide_map)
+
+    # Assert
+    assert result == ["src/foo.py", "lib/bar.py"]
+
+
+def test_files_for_role_should_preserve_input_order_and_dedupe():
+    """Test the scope lookup preserves input order and drops duplicate paths.
+
+    Given:
+        An input list containing a duplicate in-scope path.
+    When:
+        files_for_role(paths, 'architect', guide_map) is called.
+    Then:
+        The path appears once, in its first-seen position.
+    """
+    # Arrange
+    guide_map = {"role": {"src/**/*.py": ["architect"]}}
+    paths = ["src/b.py", "src/a.py", "src/b.py"]
+
+    # Act
+    result = files_for_role(paths, "architect", guide_map)
+
+    # Assert
+    assert result == ["src/b.py", "src/a.py"]
+
+
+def test_files_for_role_should_return_empty_when_role_unmapped():
+    """Test the scope lookup returns an empty list for a role with no globs.
+
+    Given:
+        A guide-map.role with no glob listing the requested role.
+    When:
+        files_for_role(paths, 'ghost', guide_map) is called.
+    Then:
+        An empty list is returned even though paths are supplied.
+    """
+    # Arrange
+    guide_map = {"role": {"src/**/*.py": ["architect"]}}
+    paths = ["src/foo.py", "tests/bar.py"]
+
+    # Act
+    result = files_for_role(paths, "ghost", guide_map)
+
+    # Assert
+    assert result == []
+
+
+def test_files_for_role_should_return_all_paths_for_general_purpose():
+    """Test the general-purpose role scopes the whole diff via its '**/*' glob.
+
+    Given:
+        The shipped default config's guide-map and arbitrary changed paths.
+    When:
+        files_for_role(paths, 'general-purpose', guide_map) is called.
+    Then:
+        Every input path is returned, since '**/*' matches the whole diff.
+    """
+    # Arrange
+    guide_map = load_package_default()["guide-map"]
+    paths = ["src/foo.py", "README.md", "Dockerfile"]
+
+    # Act
+    result = files_for_role(paths, "general-purpose", guide_map)
+
+    # Assert
+    assert result == paths
 
 
 def test_load_state_should_use_package_default_when_no_user_config(tmp_path, monkeypatch):

--- a/tests/test_pr_state.py
+++ b/tests/test_pr_state.py
@@ -92,6 +92,39 @@ def _graphql_args(owner, repo, pr_number):
     )
 
 
+_CLOSING_QUERY = (
+    "query=query($owner: String!, $repo: String!, $pr: Int!) "
+    "{ repository(owner: $owner, name: $repo) { pullRequest(number: $pr) "
+    "{ closingIssuesReferences(first: 10) { nodes { number } } } } }"
+)
+
+
+def _closing_graphql_args(owner, repo, pr_number):
+    return (
+        "api", "graphql",
+        "-f", _CLOSING_QUERY,
+        "-f", f"owner={owner}",
+        "-f", f"repo={repo}",
+        "-F", f"pr={pr_number}",
+    )
+
+
+def _closing_payload(numbers):
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "closingIssuesReferences": {
+                            "nodes": [{"number": n} for n in numbers]
+                        }
+                    }
+                }
+            }
+        }
+    )
+
+
 def test_dispatch_with_issue_and_no_linked_pr(monkeypatch):
     """Test dispatch returns None for a fresh issue with no linked PR.
 
@@ -362,6 +395,113 @@ def test_dispatch_with_fork_repo(monkeypatch):
     # Assert
     assert isinstance(result, PrContext)
     assert result.pr_number == 42
+
+
+def test_closing_issue_should_resolve_via_closing_references(monkeypatch):
+    """Test closing_issue resolves the linked issue from closingIssuesReferences.
+
+    Given:
+        PR 42's closingIssuesReferences connection names issue 7.
+    When:
+        closing_issue(42) is called.
+    Then:
+        It should return 7 without consulting the PR body.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.closing_issue(42)
+
+    # Assert
+    assert result == 7
+
+
+def test_closing_issue_should_fall_back_to_body_keyword_when_references_empty(
+    monkeypatch,
+):
+    """Test closing_issue parses the PR body when the connection is empty.
+
+    Given:
+        PR 42 has an empty closingIssuesReferences connection but a body that
+        says "Closes #7".
+    When:
+        closing_issue(42) is called.
+    Then:
+        It should return 7 from the PR-body keyword fallback.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([]),
+        (
+            "pr", "view", "42", "--json", "body", "--jq", ".body",
+        ): "Implements the widget.\n\nCloses #7\n",
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.closing_issue(42)
+
+    # Assert
+    assert result == 7
+
+
+def test_closing_issue_should_return_none_when_pr_has_no_linked_issue(monkeypatch):
+    """Test closing_issue returns None when neither surface names an issue.
+
+    Given:
+        PR 42 has an empty closingIssuesReferences connection and a body with
+        no closing keyword.
+    When:
+        closing_issue(42) is called.
+    Then:
+        It should return None.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([]),
+        (
+            "pr", "view", "42", "--json", "body", "--jq", ".body",
+        ): "A standalone change with no linked issue.\n",
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.closing_issue(42)
+
+    # Assert
+    assert result is None
+
+
+def test_closing_issue_should_route_to_upstream_when_fork(monkeypatch):
+    """Test closing_issue queries upstream when the current repo is a fork.
+
+    Given:
+        gh repo view reports the repo is a fork of upstream/sdlc and PR 42's
+        connection names issue 7.
+    When:
+        closing_issue(42) is called.
+    Then:
+        It should resolve 7 using the upstream owner/repo in the graphql call.
+    """
+    # Arrange
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_FORK,
+        _closing_graphql_args("upstream", "sdlc", 42): _closing_payload([7]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act
+    result = pr_state.closing_issue(42)
+
+    # Assert
+    assert result == 7
 
 
 class TestFindings:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -13,6 +13,7 @@ from sdlc.server import (
     get_style_guide,
     get_test_guide,
     knowledge_graph,
+    review_template,
     role_template,
     sdlc_commit,
     sdlc_guides_for,
@@ -21,6 +22,7 @@ from sdlc.server import (
     sdlc_pr,
     sdlc_review,
     sdlc_role,
+    sdlc_role_scope,
     sdlc_roles,
     sdlc_test,
     sdlc_understand_chat,
@@ -355,7 +357,7 @@ async def test_sdlc_pr_should_append_target_directive_when_target_given():
 
 
 @pytest.mark.asyncio
-async def test_sdlc_review_should_interpolate_pr_number():
+async def test_sdlc_review_should_interpolate_pr_number(monkeypatch):
     """Test sdlc_review returns skill content with interpolated PR number.
 
     Given:
@@ -365,12 +367,202 @@ async def test_sdlc_review_should_interpolate_pr_number():
     Then:
         It should return review skill content with #10 appended.
     """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
     # Act
     result = await sdlc_review(pr_number=10)
 
     # Assert
     assert "# Review Skill" in result
     assert "#10" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_default_to_general_purpose_role_when_roles_omitted(
+    monkeypatch,
+):
+    """Test sdlc_review applies the general-purpose role default when roles omitted.
+
+    Given:
+        A PR number and no roles argument.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should name the general-purpose role in the appended composition.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    assert "Roles: general-purpose" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_default_reviewers_per_role_to_one(monkeypatch):
+    """Test sdlc_review defaults the per-role reviewer count to one.
+
+    Given:
+        A PR number and no subagents argument.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should report one reviewer per role.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    assert "Reviewers per role: 1" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_list_all_roles_when_multiple_given(monkeypatch):
+    """Test sdlc_review renders every supplied role in the composition.
+
+    Given:
+        A PR number and a roles list of two roles.
+    When:
+        sdlc_review(pr_number=10, roles=["architect", "security"]) is called.
+    Then:
+        It should name both roles in the appended composition.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10, roles=["architect", "security"])
+
+    # Assert
+    assert "Roles: architect, security" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_report_subagent_count_when_given(monkeypatch):
+    """Test sdlc_review reports the requested per-role reviewer count.
+
+    Given:
+        A PR number and subagents=5.
+    When:
+        sdlc_review(pr_number=10, subagents=5) is called.
+    Then:
+        It should report five reviewers per role.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10, subagents=5)
+
+    # Assert
+    assert "Reviewers per role: 5" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_inline_review_template(monkeypatch):
+    """Test sdlc_review inlines the consolidated-review-document template.
+
+    Given:
+        A PR number.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should include the template's blocking and advisory tier headings.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    assert "## Tier 1 — Blocking" in result
+    assert "## Tier 2 — Advisory" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_append_resolved_issue_directive_when_linked(
+    monkeypatch,
+):
+    """Test sdlc_review appends the resolved issue and its document directory.
+
+    Given:
+        closing_issue resolves PR 10 to linked issue 7.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should append the resolved issue number and the issue's review
+        document directory.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: 7)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    assert "Resolved issue: #7" in result
+    assert "Review document directory: .sdlc/reviews/issue-#7/" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_note_unresolved_when_no_linked_issue(monkeypatch):
+    """Test sdlc_review notes an unresolved issue when the PR has no link.
+
+    Given:
+        closing_issue returns None for PR 10.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should append an unresolved notice instead of a document directory.
+    """
+    # Arrange
+    monkeypatch.setattr(pr_state, "closing_issue", lambda pr_number: None)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    directive = (
+        result.split("Reviewers per role: 1\n", 1)[1]
+        .split("\n\nReview document template:", 1)[0]
+    )
+    assert directive.startswith("Resolved issue: unresolved")
+    assert "Review document directory:" not in directive
+
+
+@pytest.mark.asyncio
+async def test_sdlc_review_should_degrade_when_issue_resolution_unavailable(
+    monkeypatch,
+):
+    """Test sdlc_review degrades gracefully when gh resolution fails.
+
+    Given:
+        closing_issue raises GhUnavailable for PR 10.
+    When:
+        sdlc_review(pr_number=10) is called.
+    Then:
+        It should still return the review skill with an unresolved-issue notice
+        rather than propagating the error.
+    """
+    # Arrange
+    def raise_unavailable(pr_number):
+        raise GhUnavailable("gh missing")
+
+    monkeypatch.setattr(pr_state, "closing_issue", raise_unavailable)
+
+    # Act
+    result = await sdlc_review(pr_number=10)
+
+    # Assert
+    assert "# Review Skill" in result
+    assert "Resolved issue: unresolved" in result
 
 
 @pytest.mark.asyncio
@@ -524,6 +716,25 @@ async def test_role_template_should_return_template_content():
 
 
 @pytest.mark.asyncio
+async def test_review_template_should_return_template_content():
+    """Test the review-template resource serves the bundled review template.
+
+    Given:
+        The package bundles src/sdlc/review-template.md.
+    When:
+        review_template() is called.
+    Then:
+        It should return the blocking and advisory severity-tier headings.
+    """
+    # Act
+    result = await review_template()
+
+    # Assert
+    assert "## Tier 1 — Blocking" in result
+    assert "## Tier 2 — Advisory" in result
+
+
+@pytest.mark.asyncio
 async def test_sdlc_roles_should_include_general_purpose_uri():
     """Test sdlc_roles lists the bundled general-purpose role as a URI.
 
@@ -557,6 +768,45 @@ async def test_sdlc_roles_should_return_role_uris():
 
     # Assert
     assert all(uri.startswith("sdlc://guides/role/") for uri in result)
+
+
+@pytest.mark.asyncio
+async def test_sdlc_role_scope_should_return_all_paths_for_general_purpose():
+    """Test sdlc_role_scope scopes the whole diff to the general-purpose role.
+
+    Given:
+        The bundled default guide-map maps general-purpose to '**/*'.
+    When:
+        sdlc_role_scope(paths, role="general-purpose") is called.
+    Then:
+        Every supplied path is returned in scope.
+    """
+    # Arrange
+    paths = ["src/sdlc/server.py", "README.md"]
+
+    # Act
+    result = await sdlc_role_scope(paths=paths, role="general-purpose")
+
+    # Assert
+    assert result == paths
+
+
+@pytest.mark.asyncio
+async def test_sdlc_role_scope_should_return_empty_for_unknown_role():
+    """Test sdlc_role_scope returns no files for a role with no guide-map entry.
+
+    Given:
+        A role stem not mapped to any glob in the bundled guide-map.role.
+    When:
+        sdlc_role_scope(paths, role="nonexistent") is called.
+    Then:
+        It should return an empty list regardless of the supplied paths.
+    """
+    # Act
+    result = await sdlc_role_scope(paths=["src/sdlc/server.py"], role="nonexistent")
+
+    # Assert
+    assert result == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Rework the `review` stage to produce a consolidated local review document instead of posting an inline GitHub review. `sdlc_review` now spawns N reviewer subagents per role (`subagents × len(roles)` total), each reviewing the PR diff through one role's lens and confined to the files that role is mapped to in `guide-map.role`, and the main session agent consolidates their findings — deduped within a role, merged across roles with highest-severity-wins — into a single `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. Nothing is posted to GitHub: the document is a local artifact the user or agent reads to drive fixups manually.

The approach reuses the existing role configuration model rather than inventing a new one. Roles are selected by name (defaulting to `general-purpose`), and the changed files a role's findings are confined to are computed by a reverse lookup over the already-merged `guide-map.role` — the inverse of `sdlc_guides_for`'s path-to-stems direction — so a reviewer's in-scope file set comes from ground truth instead of prose. The linked issue that names the review directory is resolved authoritatively through GitHub's `closingIssuesReferences` connection, with a `Closes`/`Fixes`/`Resolves #N` body-keyword fallback.

The main trade-off is that the review output is decoupled from GitHub: because nothing is posted, a later `sdlc_implement` call routes to `implement-continue` rather than `implement-feedback`, and the findings are not auto-ingested — the user or agent must surface them and apply each finding's pre-selected remediation as a manual work list. When a PR closes more than one issue, `<N>` resolves to one closing issue (the connection has no ordering guarantee), not necessarily the only one.

Closes #16

## Proposed changes

### Resolve a PR's linked issue via `closingIssuesReferences`

Add `closing_issue(pr_number)` to `pr_state.py`, which resolves the target repository (routing to upstream when the current repo is a fork) and returns the issue the PR closes. Resolution queries GitHub's `closingIssuesReferences` connection — the authoritative set of issues that close when the PR merges, whether linked via a keyword or the GitHub UI — and falls back to scanning the PR body for a `Closes`/`Fixes`/`Resolves #N` keyword only when the connection is empty, returning `None` when neither surface yields a linked issue. This relationship check is deterministic and does not depend on parsing prose. The module now also raises `GhUnavailable` when `gh` is missing, unauthenticated, or errors.

### Add a role-to-files reverse lookup and the `sdlc_role_scope` tool

Add `globs_for_role(role, guide_map)` and `files_for_role(paths, role, guide_map)` to `guides.py`. The former returns the glob patterns scoping a role under `guide-map.role` (order-preserving, de-duplicated); the latter composes it with the same `PurePath.full_match` semantics `resolve_guides` uses to return the subset of changed paths in scope for a role. Expose `files_for_role` as the `sdlc_role_scope(paths, role)` MCP tool, which runs the lookup over the server's already-merged config so the review skill scopes each reviewer to its role's files instead of re-deriving the merge and glob match by hand. An empty result means the role maps to none of the given paths — callers must distinguish a discovered-but-unmatched role from an unmapped one.

### Add the consolidated-review-document template resource

Add `src/sdlc/review-template.md` and serve it at the `sdlc://review-template` resource via a new `review_template()` endpoint. The template defines the exact document structure: a header (roles used, reviewers per role, target HEAD sha, dedup approach, severity legend, branch commit map), findings grouped by severity tier (blocking first) — each with a stable ID, title, severity, a `Reference` (`file:line` or a file-level / issue-level reference for a line-less finding), an Issue section with evidence, a Remediation checklist that pre-selects the recommended option (`[x]`) with alternatives (`[ ]`) and an `Other: ___` slot, an optional Tests-to-add section, and a Touched commit — plus cross-cutting-decisions and fixup-mapping sections.

### Rework `sdlc_review` with composition parameters

Give `sdlc_review` `roles` (defaulting to `["general-purpose"]`) and `subagents` (defaulting to `1`) parameters. The tool resolves the linked issue via `closing_issue`, degrading to an unresolved-issue notice rather than propagating `GhUnavailable`, and appends to the skill prompt: the target PR, the role list, the reviewers-per-role count, a resolved-issue directive (the issue number and its `.sdlc/reviews/issue-#<N>/` directory, or an unresolved notice instructing the agent to ask the user), and the inlined review-document template.

### Rework the `review` skill to produce a local document

Rewrite `skills/review.md` so the skill writes a local consolidated document instead of posting to GitHub. The pipeline now fetches the PR metadata, diff, and a branch commit map; resolves the review-document path and the 1-based iteration; validates and resolves each role's lens and `sdlc_role_scope` file set; dispatches N reviewer subagents per role into fresh contexts (each given the full diff text, guides, optional architectural context, and its in-scope files, and instructed to return structured findings only — never to write, post, or attribute commits); consolidates findings (dedup within role, merge across roles, highest severity wins, stable IDs, pre-selected remediations, commit attribution); presents the document for approval; and only then writes it. The invariants now forbid any GitHub posting, require exactly one document per completed run, and gate writing on explicit user approval. Edge cases cover unknown/misspelled roles, roles with no `guide-map.role` entry, roles whose globs match no changed file, an unresolved linked issue, and the clean (no-findings) path.

### Update documentation

Update `README.md` and `src/sdlc/AGENTS.md` to describe the role-driven, local-document review model: the `.sdlc/reviews/` convention, the `sdlc_role_scope` tool and `sdlc://review-template` resource, the `guide-map.role` reverse lookup, and the fact that the review document is a manual work list not ingested by `sdlc_implement`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_guides.py` — `globs_for_role` | A `guide-map.role` mapping globs to roles, including shared, unmapped, absent-namespace, and the shipped default cases | `globs_for_role` is called for a role | Returns every glob listing that role in map order, or empty when none maps to it | Role-to-globs reverse lookup |
| 2 | `test_guides.py` — `files_for_role` | A `guide-map.role` and a mix of in-scope and out-of-scope paths | `files_for_role` is called for a role | Returns only matching paths, unions matches across globs, preserves input order, de-dupes, and returns empty for an unmapped role | Role-to-files scope resolution |
| 3 | `test_guides.py` — general-purpose default | The shipped default config `guide-map` | The `general-purpose` role is resolved | Maps to the `**/*` whole-diff glob and scopes every supplied path | Default whole-diff role scope |
| 4 | `test_pr_state.py` — `closing_issue` | A PR whose `closingIssuesReferences` connection names an issue, or is empty with a `Closes #N` body, or is empty with no keyword | `closing_issue` is called | Resolves via the connection, falls back to the body keyword, or returns `None` when neither names an issue | Linked-issue resolution and fallback |
| 5 | `test_pr_state.py` — fork routing | `gh repo view` reports the repo is a fork of upstream | `closing_issue` is called | Resolves the issue using the upstream owner and repo in the graphql call | Fork-to-upstream routing |
| 6 | `test_server.py` — `sdlc_review` composition | A PR number with roles and `subagents` omitted or supplied | `sdlc_review` is called | Defaults to the `general-purpose` role and one reviewer, lists every supplied role, reports the requested reviewer count, and inlines the template tier headings | Composition-parameter interpolation |
| 7 | `test_server.py` — `sdlc_review` issue directive | `closing_issue` resolves an issue, returns `None`, or raises `GhUnavailable` | `sdlc_review` is called | Appends the resolved issue and its review directory, a bare unresolved notice with no directory, or degrades to an unresolved notice without propagating the error | Resolved-issue directive and graceful degradation |
| 8 | `test_server.py` — `sdlc_role_scope` and `review_template` | The bundled default `guide-map` and the bundled template file | `sdlc_role_scope` or `review_template` is called | Scopes the whole diff to `general-purpose`, returns empty for an unmapped role, and serves the template's tier headings | Role-scope tool and template resource |
