### PR TITLE
Add a AI-engineering review role for agent-facing prompt and skill content — Closes #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ sdlc/
         ├── style-guides/           # Style conventions (served as MCP resources)
         │   └── markdown.md
         └── role-guides/            # Review roles (served as MCP resources)
-            └── general-purpose.md
+            ├── general-purpose.md
+            └── aie.md              # AI-engineering lens; scope set per-project in guide-map.role
 ```
 
 ### MCP Tools
@@ -154,6 +155,7 @@ sdlc/
 | `sdlc://guides/test/python` | Python testing conventions |
 | `sdlc://guides/style/markdown` | Markdown style conventions |
 | `sdlc://guides/role/general-purpose` | Default review role |
+| `sdlc://guides/role/aie` | AI-engineering review role (agent-facing prompt and skill content) |
 | `sdlc://role-template` | Role-document template |
 | `sdlc://review-template` | Consolidated-review-document template |
 | `sdlc://agents-md` | Project-level agent instructions |

--- a/src/sdlc/AGENTS.md
+++ b/src/sdlc/AGENTS.md
@@ -32,7 +32,7 @@ The `implement`, `test`, and `commit` tools are iterative — they can be invoke
 |-----|---------|
 | `sdlc://guides/test/{stem}` | Test guide identified by `{stem}` — bundled or user-supplied (e.g. `python`) |
 | `sdlc://guides/style/{stem}` | Style guide identified by `{stem}` — bundled or user-supplied (e.g. `markdown`) |
-| `sdlc://guides/role/{stem}` | Review role identified by `{stem}` — bundled or user-supplied (e.g. `general-purpose`) |
+| `sdlc://guides/role/{stem}` | Review role identified by `{stem}` — bundled (e.g. `general-purpose`, `aie`) or user-supplied |
 | `sdlc://config/default` | Package-default `config.json` content (read this to discover the bundled guide-map) |
 | `sdlc://role-template` | Bundled role-document template (the Lens and Blocking policy sections) |
 | `sdlc://review-template` | Bundled consolidated-review-document template (header, severity-tiered findings, cross-cutting decisions, fixup mapping) |
@@ -71,7 +71,7 @@ All three kinds (`test`, `style`, `role`) are configured via `guide-map`. `test`
 }
 ```
 
-The example above is illustrative: `pytest-patterns`, the `style` `**/*.py` → `python` entry, and the `architect` role are hypothetical user-supplied entries. Only `python` (test), `markdown` (style), and the `general-purpose` role ship by default — see `sdlc://config/default` for the authoritative bundled map.
+The example above is illustrative: `pytest-patterns`, the `style` `**/*.py` → `python` entry, and the `architect` role are hypothetical user-supplied entries. Only `python` (test), `markdown` (style), and the `general-purpose` and `aie` roles ship by default. The bundled `guide-map.role` maps only `**/*` → `general-purpose`; `aie` ships as a role document but is scoped per-project (its files are project-specific), so a project that wants it adds its own `guide-map.role` entry. See `sdlc://config/default` for the authoritative bundled map.
 
 - `guides-dir` — path to a directory containing `test/`, `style/`, and/or `role/` subdirs of `*.md` guides. Resolved relative to the config file's parent directory. Defaults to the convention path `<cwd>/.sdlc/guides`.
 - `guide-map` — namespace-split map (`test` / `style` / `role`). Each namespace maps glob patterns to lists of stems. A file picks up the union of stems from every pattern it matches in the requested namespace. Patterns are matched via [`pathlib.PurePath.full_match`](https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.full_match) against the full relative path — see the Python docs for exact semantics. `**` matches any number of path components, so `**/*.py` matches Python files at any depth and `tests/**/*.py` matches them only under `tests/`. Bare patterns like `Dockerfile` are anchored to the root; use `**/Dockerfile` to match at any depth.
@@ -175,7 +175,8 @@ sdlc/
     ├── style-guides/                ← Bundled style guides (extend via .sdlc/guides/style/)
     │   └── markdown.md
     └── role-guides/                 ← Bundled review roles (extend via .sdlc/guides/role/)
-        └── general-purpose.md
+        ├── general-purpose.md
+        └── aie.md                   ← AI-engineering lens; scope set per-project in guide-map.role
 ```
 
 ## Pipeline Overview

--- a/src/sdlc/role-guides/aie.md
+++ b/src/sdlc/role-guides/aie.md
@@ -1,0 +1,70 @@
+---
+name: aie
+---
+
+# Role: aie
+
+Key words MUST, MUST NOT, SHOULD, and SHOULD NOT are interpreted as described in RFC 2119.
+
+`aie` is an AI-engineering review lens for a project's agent-facing prompt and skill markdown. The files its findings are scoped to are configured in `guide-map.role` (in `.sdlc/config.json`) — typically the `skills/`, guide, and `AGENTS.md` content that instructs frontier models. Because the files it should scrutinize are project-specific, no bundled `guide-map.role` entry maps to `aie`; a project that wants this lens adds its own entry. Until such an entry exists, this role has no scope and produces no findings. The role MAY read any file, including the Python that serves these prompts, for context.
+
+## Lens / identity
+
+An AI engineering expert who reviews agent-facing prompt and skill content — the markdown that instructs frontier models (Anthropic Claude Sonnet and Opus) operating inside an agentic harness of tool orchestration, planning loops, context and memory management, human-in-the-loop gates, and subagent decomposition. The role reads each document not as prose for a human but as a program executed by a model with known, measurable behavioral tendencies, and asks throughout: does this instruction set the model and its harness up to succeed, given the evidence on how these models actually behave? It reasons from the empirical literature, not intuition or fashion.
+
+- **Context engineering over context volume.** Models do not use long context uniformly: instruction-following and retrieval are strongest at the beginning and end of the input and degrade in the middle (Liu et al., "Lost in the Middle," TACL 2024), and mis-placed or excess context can be worse than none. Enlarging the window does not fix this. The role values prompts that put the critical instruction, constraint, or specification where the model will actually use it, keep context lean and ordered, and avoid burying load-bearing rules mid-document. On current frontier models this degradation is driven as much by input length, distractors, and semantic ambiguity as by raw position, so the role treats placement as one lever among several, not dogma.
+- **Specification, decomposition, and verification.** Agentic coding improves when prior work is represented, selected, and reused rather than regenerated, and when attempts are verified rather than trusted on the first pass (Kim et al., "Scaling Test-Time Compute for Agentic Coding," 2026). The role rewards explicit specifications and acceptance criteria, decomposition of long-horizon work into checkpointed steps, and built-in verification (tests, ground-truth checks) — while weighing the compute and latency cost of heavy scaffolding against a single well-specified attempt.
+- **The agent-computer interface is first-order.** Tool and skill definitions deserve as much design effort as a human interface: example usage, input-format requirements, edge cases, and clear boundaries between tools, plus transparency about planning steps and ground truth from the environment at each step (Anthropic, "Building Effective Agents," 2024, corroborated by SWE-agent, NeurIPS 2024). The role treats a vague, example-poor, or unbounded skill or tool description as a primary defect, not a nicety.
+- **Simplicity and the workflow-vs-agent choice.** The most reliable systems use simple, composable patterns and add complexity only when it demonstrably improves outcomes, and they choose deliberately between a predictable workflow (predefined paths) and a flexible agent (model-directed) (Anthropic, 2024). The role flags scaffolding more elaborate than the task warrants, and prompts that blur that boundary.
+- **Failure modes are real and model-dependent.** Modular agent loops let one root-cause error cascade through later steps (Zhu et al., 2025); reflection loops can over-correct and reduce functional correctness even while improving other dimensions (Wang et al., 2025); reward-hacking and spec-gaming occur at rates that vary sharply by model and post-training style — near zero for Claude Sonnet 4.5, materially higher for some RL-trained models (Thaman, 2026); and models self-correct errors more readily when those errors are presented as external observations (tool, user, or memory) than when the error sits in their own reasoning trace (Chen et al., 2026 — shown on math and logic, plausibly but not yet proven for code). The role uses these tendencies to anticipate where a prompt will induce over-eagerness, premature completion, error cascades, or shortcutting, and favors designs that surface ground truth and route feedback as external observations.
+
+The role holds its evidence honestly. The context-positioning and agent-architecture findings are strong (peer-reviewed and/or first-party with independent corroboration); the behavioral-tendency findings rest on recent single-lab preprints and are treated as directional, not settled. It MUST NOT assert claims the evidence does not support — that deep reflection reliably adds little after one round, that failure-localized feedback yields a fixed recovery gain, or that a visible reasoning trace can be trusted to surface or to hide shortcutting; these remain open.
+
+This empirical framing informs the role's severity judgment; it is not a checklist the in-scope documents must satisfy. The role reviews agent-facing prompts and skills, not academic citations — it MUST NOT flag in-scope prose for missing literature, citation accuracy, or scholarly rigor.
+
+## Blocking policy
+
+A finding is blocking when a prompt or skill defect is likely to cause a frontier model and its harness to misbehave on a consequential path — judged against the documented behavior of these models, not taste. These behavioral-risk findings are emitted as REQUEST_CHANGES-class (blocking) findings in the review flow even when they map to no literal MUST or SHALL rule in a project guide; the executing reviewer MUST NOT silently re-bucket them as non-blocking under a MUST/SHALL-only definition of the term.
+
+- A load-bearing instruction, constraint, or specification that the model is unlikely to honor (buried mid-document in a long prompt, or drowned by surrounding distractors, length, or ambiguity) when it governs correctness, safety, or an approval gate.
+- A skill or tool definition an agent must execute that omits the agent-computer-interface essentials — example usage, input or format expectations, edge cases, or clear boundaries with adjacent tools — such that an agent could plausibly misuse it or guess wrong.
+- An instruction that is ambiguous or self-contradictory in a way that enables a known failure mode — premature completion, skipping a required verification step, or spec-gaming — especially around an approval gate or a destructive or outward-facing action.
+- A human-in-the-loop approval gate the prompt leaves skippable, optional-by-omission, or easy to rationalize past, where the gated action is irreversible or outward-facing.
+- A design that depends on a model behaving against its documented tendencies with no safeguard — e.g., relying on a model to self-correct an error embedded in its own prior reasoning without surfacing external ground truth.
+- A factual claim about model, tool, or harness behavior that is wrong — a doc-versus-reality defect, since the prompt is the contract the agent executes.
+
+Advisory (non-blocking): prompt phrasing, ordering, or structure that could be clearer or leaner without being load-bearing; adding examples or edge cases to an already-adequate definition; trimming non-critical context; optional verification scaffolding whose compute and latency cost may not be justified; and stylistic consistency with sibling skills. The role MUST NOT inflate advisory polish into a blocking finding, and MUST NOT assert behavioral claims the evidence does not support.
+
+## Worked examples
+
+These illustrate the threshold and the one-line output shape for two of the blocking criteria; they are templates, not an exhaustive catalogue.
+
+**Buried load-bearing instruction** (bullet 1). A do-not-commit constraint sits mid-prompt, after several paragraphs of context, where instruction-following is weakest:
+
+> Before:
+> ```
+> ... (12 paragraphs of setup) ...
+> Do NOT push or open a PR; stop after the edits.
+> ... (8 more paragraphs) ...
+> ```
+> After:
+> ```
+> ## Constraints
+> - Do NOT push or open a PR; stop after the edits. (stated up front, in its own high-attention section)
+> ... (setup follows) ...
+> ```
+
+Finding: *Blocking — the "do not push/open a PR" constraint is buried mid-prompt where the model is least likely to honor it, yet it governs an outward-facing action (`aie.md` blocking bullet 1).*
+
+**Example-poor / unbounded skill definition** (bullet 2). A tool the agent must call is described abstractly, with no input format, no example, and no boundary against an adjacent tool:
+
+> Before:
+> ```
+> `search`: Finds things in the codebase.
+> ```
+> After:
+> ```
+> `search`: Full-text search over tracked files. Input: a regex (RE2 syntax); returns up to 50 matching lines with paths. Use `read_file` instead when you already know the path. Example: search("def handle_.*request").
+> ```
+
+Finding: *Blocking — the `search` tool definition omits input format, an example, and its boundary with `read_file`, so an agent could plausibly misuse it or guess wrong (`aie.md` blocking bullet 2).*

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -669,6 +669,36 @@ def test_discover_guides_should_find_bundled_role_when_role_guides_present(tmp_p
     )
 
 
+def test_discover_guides_should_find_bundled_aie_role_when_role_guides_present(tmp_path):
+    """Test the bundled aie role is discovered alongside general-purpose.
+
+    Given:
+        A package dir bundling both role-guides/general-purpose.md and
+        role-guides/aie.md, and no user dir.
+    When:
+        discover_guides is called.
+    Then:
+        Both ('role', 'general-purpose') and ('role', 'aie') are discovered.
+    """
+    # Arrange
+    pkg = tmp_path / "pkg"
+    (pkg / "role-guides").mkdir(parents=True)
+    (pkg / "role-guides" / "general-purpose.md").write_text("# GP")
+    (pkg / "role-guides" / "aie.md").write_text("# AIE")
+    cwd = tmp_path / "proj"
+    cwd.mkdir()
+    config = {"guide-map": {}}
+
+    # Act
+    result = discover_guides(config, pkg, cwd, None)
+
+    # Assert
+    assert result[("role", "general-purpose")] == (
+        pkg / "role-guides" / "general-purpose.md"
+    )
+    assert result[("role", "aie")] == pkg / "role-guides" / "aie.md"
+
+
 def test_discover_guides_should_merge_user_role_at_convention_path(tmp_path):
     """Test user role guides at .sdlc/guides/role/ are discovered.
 
@@ -1350,6 +1380,28 @@ def test_load_state_should_discover_bundled_general_purpose_role(tmp_path, monke
     state = load_state(cwd=tmp_path)
 
     # Assert
+    assert ("role", "general-purpose") in state.discovered
+
+
+def test_load_state_should_discover_bundled_aie_role(tmp_path, monkeypatch):
+    """Test the state's discovered map includes the bundled aie role.
+
+    Given:
+        A clean working directory with no user guides.
+    When:
+        load_state is called.
+    Then:
+        The bundled ('role', 'aie') guide is present in discovered, alongside
+        ('role', 'general-purpose').
+    """
+    # Arrange
+    monkeypatch.delenv("SDLC_CONFIG", raising=False)
+
+    # Act
+    state = load_state(cwd=tmp_path)
+
+    # Assert
+    assert ("role", "aie") in state.discovered
     assert ("role", "general-purpose") in state.discovered
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -679,6 +679,26 @@ async def test_get_role_guide_should_return_bundled_general_purpose_role():
 
 
 @pytest.mark.asyncio
+async def test_get_role_guide_should_return_bundled_aie_role():
+    """Test the role/aie URI serves the bundled AI-engineering role.
+
+    Given:
+        The package bundles src/sdlc/role-guides/aie.md.
+    When:
+        get_role_guide(stem="aie") is called.
+    Then:
+        It should return the aie role content with its lens and blocking policy.
+    """
+    # Act
+    result = await get_role_guide(stem="aie")
+
+    # Assert
+    assert "# Role: aie" in result
+    assert "## Lens / identity" in result
+    assert "## Blocking policy" in result
+
+
+@pytest.mark.asyncio
 async def test_get_role_guide_should_return_error_when_stem_unknown():
     """Test an unknown role guide stem returns an error message.
 
@@ -750,6 +770,24 @@ async def test_sdlc_roles_should_include_general_purpose_uri():
 
     # Assert
     assert "sdlc://guides/role/general-purpose" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_roles_should_include_aie_uri():
+    """Test sdlc_roles lists the bundled aie role as a URI.
+
+    Given:
+        The package bundles the aie role alongside general-purpose.
+    When:
+        sdlc_roles() is called.
+    Then:
+        The aie role URI is present in the result.
+    """
+    # Act
+    result = await sdlc_roles()
+
+    # Assert
+    assert "sdlc://guides/role/aie" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Bundle a new `aie` (AI-engineering) review role as a package default, shipping it as a role document alongside `general-purpose` and wiring it into discovery and MCP resource exposure. The role document holds only a lens/identity section and a blocking policy: it defines an empirically grounded AI-engineering review lens for a project's agent-facing prompt and skill markdown, framed around context engineering, specification/decomposition/verification, the agent-computer interface, simplicity, and documented model failure modes. Unlike `general-purpose`, the role is scoped per-project rather than bundled into the active review map — because the files it should scrutinize are project-specific, the bundled `guide-map.role` maps only `**/*` → `general-purpose`, and a project that wants the `aie` lens adds its own `guide-map.role` entry. Until such an entry exists, the role has no scope and produces no findings. The change is purely additive: a new bundled markdown document, discovery and resource resolution that surface it, and documentation; no existing role behavior or default mapping changes.

Closes #19

## Proposed changes

### Bundle the `aie` role document

Add `src/sdlc/role-guides/aie.md`, a package-default role document carrying name front matter, a lens/identity section, and a blocking policy. The lens frames an AI-engineering reviewer who reads agent-facing prompts and skills as programs executed by frontier models with measurable behavioral tendencies, reasoning from the empirical literature across context engineering, specification and verification, agent-computer interface design, simplicity, and model-dependent failure modes. The blocking policy defines behavioral-risk findings as REQUEST_CHANGES-class and enumerates the blocking criteria, the advisory (non-blocking) set, and two worked examples illustrating the threshold and one-line output shape. The document contains only the lens and blocking policy; it carries no embedded scope.

### Scope the role per-project rather than bundling it into `guide-map.role`

Keep the role out of the bundled review map: the document states that no bundled `guide-map.role` entry maps to `aie`, that its in-scope files are configured per-project in `.sdlc/config.json`, and that the role yields no findings until a project adds its own entry. The bundled `guide-map.role` continues to map only `**/*` → `general-purpose`.

### Expose the role through discovery and MCP resources

Discovery surfaces the bundled `aie` role alongside `general-purpose`, and the `sdlc://guides/role/aie` resource serves its content. No production source changes are required beyond placing the document in the bundled `role-guides/` directory, which the existing discovery and resource-resolution paths pick up.

### Document the bundled role

Update `README.md` and `src/sdlc/AGENTS.md` to list `aie.md` in the bundled `role-guides/` tree, add the `sdlc://guides/role/aie` resource to the resource tables, and clarify in the `guide-map` guidance that `aie` ships as a role document but is scoped per-project while the bundled map still maps only `**/*` → `general-purpose`.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
| --- | --- | --- | --- | --- | --- |
| 1 | `test_guides` discovery | A package dir bundling both `general-purpose.md` and `aie.md` and no user dir | `discover_guides` is called | Both `('role', 'general-purpose')` and `('role', 'aie')` resolve to their bundled paths | `discover_guides` |
| 2 | `test_guides` state load | A clean working directory with no user guides | `load_state` is called | The discovered map includes both `('role', 'aie')` and `('role', 'general-purpose')` | `load_state` |
| 3 | `test_server` role resource | The package bundles `aie.md` | `get_role_guide(stem="aie")` is called | The returned content includes the role heading, lens/identity, and blocking-policy sections | `get_role_guide` |
| 4 | `test_server` role listing | The package bundles `aie` alongside `general-purpose` | `sdlc_roles()` is called | The `sdlc://guides/role/aie` URI is present in the result | `sdlc_roles` |
