### PR TITLE
Wire sdlc_implement to consume local review documents for remediation — Closes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,11 @@ If you have a PR template defined in your `.github` dir, the agent will follow t
 
 **6. Review the PR (Optional)**
 
-The agent calls `sdlc_review` with the PR number. It runs one or more reviewer roles (N reviewers per role) over the PR diff, each confined to the files its role is mapped to, then consolidates their findings — deduped, merged across roles, highest severity wins — into a single local document at `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. The document groups findings by severity (blocking first), gives each a stable ID and a `Reference`, and pre-selects a recommended remediation per finding with alternatives and an `Other` slot. You review and approve the document; nothing is posted to GitHub. The document is a local artifact you (or the agent) read to drive fixups manually — `sdlc_implement` does not ingest it, so address the findings directly using each one's pre-selected remediation and fixup-mapping entry as the work list.
+The agent calls `sdlc_review` with the PR number. It runs one or more reviewer roles (N reviewers per role) over the PR diff, each confined to the files its role is mapped to, then consolidates their findings — deduped, merged across roles, highest severity wins — into a single local document at `.sdlc/reviews/issue-#<N>/review-<iteration>.md`. The document groups findings by severity (blocking first), gives each a stable ID and a `Reference`, and pre-selects a recommended remediation per finding with alternatives and an `Other` slot. You review and approve the document; nothing is posted to GitHub. This document is exactly what `sdlc_implement` consumes to drive fixups — see the next step.
 
 **7. Iterate or Merge**
 
-If review feedback requires changes, re-enter the implementation loop with `sdlc_implement`. Address the feedback, then re-run test, commit, and pr tools as needed. When you're satisfied, mark the PR ready for review and merge via GitHub.
+If review feedback requires changes, re-enter the implementation loop with `sdlc_implement`. By default it parses the latest review document for the closing issue, renders its findings, and walks you through each one's pre-selected remediation behind a per-finding approval gate; `--review <iteration>` selects an earlier round, and `--review <pr-url>` first converts that PR's GitHub review comments into a fresh local review document. Address the feedback, then re-run test, commit, and pr tools as needed. When you're satisfied, mark the PR ready for review and merge via GitHub.
 
 ## Project Structure
 
@@ -138,7 +138,7 @@ sdlc/
 | Tool | Purpose |
 |------|---------|
 | `sdlc_issue` | Draft and push a GitHub issue |
-| `sdlc_implement` | Implement a GitHub issue, continue an in-progress PR, or address PR review feedback |
+| `sdlc_implement` | Implement a GitHub issue, continue an in-progress PR, or address a local review document's findings (`--review` selects an iteration or a PR URL to convert) |
 | `sdlc_test` | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | Stage and commit changes with atomic commits |
 | `sdlc_pr` | Review changes and create a draft pull request |
@@ -163,7 +163,7 @@ sdlc/
 
 ## What You Get
 
-The pipeline enforces disciplined commits — atomic, well-structured, with conventional-commit messages that make your history readable. It emphasizes test-first planning, generating comprehensive test specs before implementation. Code quality is enforced through guide-based, role-driven review that produces a consolidated local review document — an actionable, option-per-finding remediation plan you keep under `.sdlc/reviews/`. Every action is presented for review before execution, so you never have unwanted surprises. When you get PR feedback, you loop back to implementation, refine, and iterate. The system is tool-agnostic — any MCP-compatible client can connect. For large codebases, you can generate lightweight knowledge graphs to give the agent architectural context without shipping megabytes of source code as context.
+The pipeline enforces disciplined commits — atomic, well-structured, with conventional-commit messages that make your history readable. It emphasizes test-first planning, generating comprehensive test specs before implementation. Code quality is enforced through guide-based, role-driven review that produces a consolidated local review document — an actionable, option-per-finding remediation plan you keep under `.sdlc/reviews/`, which `sdlc_implement` then consumes to walk you through the fixups one finding at a time. Every action is presented for review before execution, so you never have unwanted surprises. When you get review feedback, you loop back to implementation, refine, and iterate. The system is tool-agnostic — any MCP-compatible client can connect. For large codebases, you can generate lightweight knowledge graphs to give the agent architectural context without shipping megabytes of source code as context.
 
 ## Documentation
 

--- a/src/sdlc/AGENTS.md
+++ b/src/sdlc/AGENTS.md
@@ -13,7 +13,7 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | Tool | Stage | Purpose |
 |------|-------|---------|
 | `sdlc_issue` | 1st | Draft and push a GitHub issue |
-| `sdlc_implement` | 2nd | Implement a GitHub issue, continue an in-progress PR, or address PR review feedback |
+| `sdlc_implement` | 2nd | Implement a GitHub issue, continue an in-progress PR, or address a local review document's findings (`--review` selects an iteration or a PR URL to convert) |
 | `sdlc_test` | 3rd | Analyze coverage and write comprehensive tests |
 | `sdlc_commit` | 4th | Stage and commit changes with atomic commits |
 | `sdlc_pr` | 5th | Review changes and create a draft pull request |
@@ -24,7 +24,19 @@ Each tool returns the full workflow instructions for its pipeline stage. The LLM
 | `sdlc_role_scope` | — | Reverse-lookup the changed files a role's findings are confined to (over the merged `guide-map.role`) |
 | `sdlc_role` | — | Author a review role document (lens, blocking policy, focus globs) |
 
-The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address PR feedback or refine implementation. `sdlc_implement` accepts either an issue number or a PR number and dispatches between three sibling skill prompts based on PR state: `implement` (fresh start, no PR yet), `implement-continue` (PR exists, no review feedback yet), and `implement-feedback` (PR has unresolved review threads or review-body comments).
+The `implement`, `test`, and `commit` tools are iterative — they can be invoked multiple times for a given issue to address review feedback or refine implementation. `sdlc_implement` accepts either an issue number or a PR number plus a polymorphic `--review` selector, and dispatches between three sibling skill prompts:
+
+- `implement` — fresh start (the number is an issue with no linked PR, and no local review document applies).
+- `implement-continue` — a PR is in scope but no local review document exists for its closing issue.
+- `implement-feedback` — a local review document is selected and its findings drive the remediation walk-through.
+
+`--review` chooses the finding source for the feedback path:
+
+- **omitted / `None`** — load the latest `.sdlc/reviews/issue-#<N>/review-<iteration>.md` for the closing issue `<N>` when one exists; otherwise fall through to `implement-continue` (linked PR) or `implement` (bare issue). Missing local docs are NOT an error on this default path.
+- **`int`** — load that exact local iteration. A missing iteration is surfaced as a clear diagnostic, never a silent fresh fallback.
+- **PR URL (`str`)** — fetch that PR's review threads and review-body comments, render them into a NEW local review document at the next iteration (never overwriting), and consume it. A string that is not a GitHub PR URL is rejected — a numeric string is never coerced into an iteration.
+
+The dispatcher no longer auto-detects GitHub review threads: GitHub findings enter the implement loop only through an explicit `--review <pr-url>` conversion. Local documents are read directly off disk and need no `gh` round-trip.
 
 #### Target-repo resolution
 
@@ -105,7 +117,9 @@ The `implement`, `test`, and `review` skills do not hardcode guide URIs. Each ca
 
 ### The `.sdlc/reviews/` convention
 
-`sdlc_review` writes a standardized local review document — it posts nothing to GitHub. Each review round is written to `.sdlc/reviews/issue-#<N>/review-<iteration>.md`, where `<N>` is the first issue the PR closes when several are linked (resolved from `closingIssuesReferences`, falling back to parsing `Closes #N` in the PR body; the connection has no ordering guarantee, so `<N>` is one closing issue, not necessarily the only one) and `<iteration>` is 1-based, one greater than the highest existing `review-*.md` for that issue. The document is structured from the bundled template (`sdlc://review-template`): a header (roles used, reviewers per role, target HEAD sha, dedup approach, severity legend, branch commit map); findings grouped by severity tier (blocking first) — each with a stable ID, title, severity, a `Reference` (`file:line`, or a file-level / issue-level reference for a line-less finding), an Issue section with evidence, a Remediation checklist where the consolidator pre-selects the recommended option (`[x]`), lists alternatives (`[ ]`), and always offers an `Other: ___` slot, an optional Tests-to-add section, and a Touched commit; plus cross-cutting-decisions and fixup-mapping sections. The document is a local artifact: the user or agent reads it and applies each finding's pre-selected remediation and fixup-mapping entry as a manual work list. It is NOT auto-consumed by `sdlc_implement` — because nothing is posted to GitHub, a subsequent `sdlc_implement` call routes to `implement-continue` (not `implement-feedback`) unless the user separately surfaces the findings.
+`sdlc_review` writes a standardized local review document — it posts nothing to GitHub. Each review round is written to `.sdlc/reviews/issue-#<N>/review-<iteration>.md`, where `<N>` is the first issue the PR closes when several are linked (resolved from `closingIssuesReferences`, falling back to parsing `Closes #N` in the PR body; the connection has no ordering guarantee, so `<N>` is one closing issue, not necessarily the only one) and `<iteration>` is 1-based, one greater than the highest existing `review-*.md` for that issue. The document is structured from the bundled template (`sdlc://review-template`): a header (roles used, reviewers per role, target HEAD sha, dedup approach, severity legend, branch commit map); findings grouped by severity tier (blocking first) — each with a stable ID, title, severity, a `Reference` (`file:line`, or a file-level / issue-level reference for a line-less finding), an Issue section with evidence, a Remediation checklist where the consolidator pre-selects the recommended option (`[x]`), lists alternatives (`[ ]`), and always offers an `Other: ___` slot, an optional Tests-to-add section, and a Touched commit; plus cross-cutting-decisions and fixup-mapping sections.
+
+This document is the finding source `sdlc_implement` consumes on its feedback path. By default a subsequent `sdlc_implement <N>` (or `sdlc_implement <pr#>`) parses the **latest** `review-<iteration>.md` for the closing issue, renders its findings, and routes to `implement-feedback` so the agent walks each finding's pre-selected remediation through a per-finding approval gate. `--review <int>` selects a specific earlier iteration instead. `sdlc_implement` reads the document straight off disk — `sdlc_review` posts nothing to GitHub, and the dispatcher no longer probes GitHub review threads. A PR's GitHub review feedback can still feed the loop, but only by explicitly converting it first: `--review <pr-url>` fetches that PR's threads and review-body comments and writes them into a fresh local review document (at the next iteration) before consuming it.
 
 ## Installation & Setup
 
@@ -185,7 +199,7 @@ sdlc/
 
 ## Pipeline Overview
 
-The typical development flow follows this sequence. Start by drafting a GitHub issue with acceptance criteria and description. Fetch the issue, create a feature branch, enter planning phase, and design a concrete implementation plan. Execute the plan by writing code and tests, guided by project context and test conventions. Optionally, analyze code changes, evaluate existing test coverage, and generate comprehensive test specifications targeting 100% coverage of public APIs. Analyze the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. Review the branch diff and create or update a draft pull request linked to the issue. Fetch the PR, review it through one or more role lenses (N reviewers per role), and consolidate the findings into a single local review document under `.sdlc/reviews/` — nothing is posted to GitHub. The document is a local artifact the user or agent reads to drive fixups manually; `sdlc_implement` does not ingest it.
+The typical development flow follows this sequence. Start by drafting a GitHub issue with acceptance criteria and description. Fetch the issue, create a feature branch, enter planning phase, and design a concrete implementation plan. Execute the plan by writing code and tests, guided by project context and test conventions. Optionally, analyze code changes, evaluate existing test coverage, and generate comprehensive test specifications targeting 100% coverage of public APIs. Analyze the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. Review the branch diff and create or update a draft pull request linked to the issue. Fetch the PR, review it through one or more role lenses (N reviewers per role), and consolidate the findings into a single local review document under `.sdlc/reviews/` — nothing is posted to GitHub. To act on the findings, re-run `sdlc_implement`: it parses the latest review document (or the `--review`-selected iteration / PR-URL conversion), renders the findings, and routes to `implement-feedback` for a per-finding, approval-gated remediation walk-through.
 
 The `implement`, `test`, and `commit` steps are iterative — you can run them multiple times to refine the implementation based on feedback or additional context. After each change, re-run `sdlc_pr` to update the PR description before final review.
 

--- a/src/sdlc/pr_state.py
+++ b/src/sdlc/pr_state.py
@@ -6,6 +6,7 @@ import json
 import re
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 
@@ -65,6 +66,62 @@ class Findings:
             lines.append(
                 f"  {index}. [{finding.kind}] {citation} — @{author}: {finding.body}"
             )
+        return "\n".join(lines)
+
+
+@dataclass(frozen=True)
+class ReviewFinding:
+    """A single finding parsed from a local ``.sdlc/reviews`` review document."""
+
+    id: str
+    title: str
+    severity: Literal["blocking", "advisory"]
+    reference: str
+    issue: str
+    remediation: str
+    touched_commit: str | None
+
+
+@dataclass(frozen=True)
+class ReviewFindings:
+    """A parsed local review document: its provenance and its findings."""
+
+    issue_number: int
+    iteration: int
+    path: str
+    findings: list[ReviewFinding]
+
+    def format(self) -> str:
+        """Render the review document as a human-readable feedback block.
+
+        The header carries the issue number, iteration, and source path so
+        the agent can re-read the document. Findings are emitted blocking
+        first, then advisory, each numbered with its id, severity, reference,
+        title, issue, and pre-selected remediation block.
+        """
+        lines = [
+            f"Review document: .sdlc/reviews/issue-#{self.issue_number}/"
+            f"review-{self.iteration}.md",
+            f"Issue: #{self.issue_number}",
+            f"Iteration: {self.iteration}",
+            f"Path: {self.path}",
+            f"Findings ({len(self.findings)}):",
+        ]
+        ordered = [f for f in self.findings if f.severity == "blocking"]
+        ordered += [f for f in self.findings if f.severity == "advisory"]
+        for index, finding in enumerate(ordered, start=1):
+            lines.append("")
+            lines.append(
+                f"  {index}. [{finding.severity}] {finding.id} — {finding.title}"
+            )
+            lines.append(f"     Reference: {finding.reference}")
+            if finding.issue:
+                lines.append(f"     Issue: {finding.issue}")
+            lines.append("     Remediation:")
+            for remediation_line in finding.remediation.splitlines():
+                lines.append(f"       {remediation_line}")
+            if finding.touched_commit is not None:
+                lines.append(f"     Touched commit: {finding.touched_commit}")
         return "\n".join(lines)
 
 
@@ -150,6 +207,400 @@ def _with_repo(args: list[str], repo_flag: str | None) -> list[str]:
     if repo_flag is None:
         return args
     return [*args, "--repo", repo_flag]
+
+
+# A PR URL passed as the ``--review`` argument: it MUST look like a GitHub PR
+# URL (``…github.com/<owner>/<repo>/pull/<n>``) so a numeric string is never
+# silently coerced into a local-iteration selector.
+_PR_URL = re.compile(
+    r"github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<number>\d+)",
+    re.IGNORECASE,
+)
+
+# Finding heading in a local review document, e.g.
+# ``### B1 — Title here **(BLOCKING)** — aie (3/10 …)`` or
+# ``### A1 — Title here — aie (4/10 …)``. The ``**(BLOCKING)**`` marker is
+# optional; the tier section the heading sits under is authoritative for
+# severity, with the marker as a secondary signal.
+_FINDING_HEADING = re.compile(
+    r"^###\s+(?P<id>\S+)\s+—\s+(?P<rest>.*)$",
+)
+_BLOCKING_MARKER = "**(BLOCKING)**"
+_TIER_BLOCKING = re.compile(r"^##\s+Tier\s+1\b.*Blocking", re.IGNORECASE)
+_TIER_ADVISORY = re.compile(r"^##\s+Tier\s+2\b.*Advisory", re.IGNORECASE)
+
+
+def _reviews_dir(issue_number: int) -> Path:
+    """Return the review-document directory for ``issue_number``.
+
+    Mirrors the cwd-relative convention `sdlc_review` writes to:
+    ``.sdlc/reviews/issue-#<N>``.
+    """
+    return Path(".sdlc/reviews") / f"issue-#{issue_number}"
+
+
+def _iterations(issue_number: int) -> list[int]:
+    """Return the sorted iteration numbers present for ``issue_number``.
+
+    Globs ``review-*.md`` in the issue's review directory and parses the
+    trailing integer from each filename. Returns an empty list when the
+    directory is absent or holds no parseable ``review-<int>.md`` file.
+    """
+    directory = _reviews_dir(issue_number)
+    if not directory.is_dir():
+        return []
+    iterations: list[int] = []
+    for path in directory.glob("review-*.md"):
+        match = re.fullmatch(r"review-(\d+)", path.stem)
+        if match:
+            iterations.append(int(match.group(1)))
+    return sorted(iterations)
+
+
+def _latest_iteration(issue_number: int) -> int | None:
+    """Return the highest iteration for ``issue_number``, or ``None``."""
+    iterations = _iterations(issue_number)
+    return iterations[-1] if iterations else None
+
+
+def _next_iteration(issue_number: int) -> int:
+    """Return the next iteration to write for ``issue_number`` (``max + 1``)."""
+    iterations = _iterations(issue_number)
+    return (iterations[-1] if iterations else 0) + 1
+
+
+def _extract_field(block: str, label: str) -> str | None:
+    """Return the inline value of a ``**Label:** value`` line in ``block``."""
+    pattern = re.compile(
+        rf"^\*\*{re.escape(label)}:\*\*\s*(?P<value>.*)$", re.MULTILINE
+    )
+    match = pattern.search(block)
+    if match is None:
+        return None
+    return match.group("value").strip()
+
+
+def _parse_finding_block(
+    finding_id: str,
+    rest: str,
+    body: str,
+    severity: Literal["blocking", "advisory"],
+) -> ReviewFinding:
+    """Build a ``ReviewFinding`` from one finding heading and its body text.
+
+    ``rest`` is the heading text after the id; ``body`` is everything between
+    this heading and the next heading / tier boundary.
+    """
+    title = rest
+    if _BLOCKING_MARKER in title:
+        title = title.split(_BLOCKING_MARKER, 1)[0]
+    # Drop a trailing `— <role / agreement>` attribution when present.
+    title = title.split(" — ", 1)[0].strip()
+
+    reference = _extract_field(body, "Reference") or ""
+    touched_commit = _extract_field(body, "Touched commit")
+
+    # The issue text is the labelled `**Issue:**` paragraph for blocking
+    # findings; advisory findings carry a bare paragraph between the Reference
+    # line and the first remediation checkbox instead.
+    issue = _extract_issue(body)
+    remediation = _extract_remediation(body)
+
+    return ReviewFinding(
+        id=finding_id,
+        title=title,
+        severity=severity,
+        reference=reference,
+        issue=issue,
+        remediation=remediation,
+        touched_commit=touched_commit,
+    )
+
+
+def _extract_issue(body: str) -> str:
+    """Return the finding's issue text.
+
+    Prefers an explicit ``**Issue:**`` paragraph; falls back to the bare
+    paragraph between the ``**Reference:**`` line and the first remediation
+    checkbox (the advisory shape in the review template).
+    """
+    lines = body.splitlines()
+    labelled: list[str] = []
+    capturing = False
+    for line in lines:
+        if line.startswith("**Issue:**"):
+            capturing = True
+            labelled.append(line[len("**Issue:**"):].strip())
+            continue
+        if capturing:
+            if line.startswith("**") or line.lstrip().startswith("- ["):
+                break
+            labelled.append(line.strip())
+    if any(labelled):
+        return "\n".join(labelled).strip()
+
+    # Advisory shape: text after the Reference line, before the first checkbox.
+    bare: list[str] = []
+    seen_reference = False
+    for line in lines:
+        if line.startswith("**Reference:**"):
+            seen_reference = True
+            continue
+        if not seen_reference:
+            continue
+        if line.lstrip().startswith("- ["):
+            break
+        if line.startswith("**"):
+            break
+        bare.append(line.strip())
+    return "\n".join(bare).strip()
+
+
+def _extract_remediation(body: str) -> str:
+    """Return the remediation checklist block verbatim.
+
+    Captures the contiguous run of ``- [ ]`` / ``- [x]`` checkbox lines
+    (and their continuations), preserving the pre-selected option, any
+    alternatives, and the ``Other:`` slot.
+    """
+    lines = body.splitlines()
+    captured: list[str] = []
+    capturing = False
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("- ["):
+            capturing = True
+            captured.append(line.rstrip())
+            continue
+        if capturing:
+            if not stripped:
+                continue
+            if (
+                stripped.startswith("**")
+                or stripped.startswith("###")
+                or stripped.startswith("---")
+            ):
+                break
+            # A continuation line of the current checkbox item.
+            captured.append(line.rstrip())
+    return "\n".join(captured).strip()
+
+
+def parse_review_document(
+    path: str | Path, issue_number: int, iteration: int
+) -> ReviewFindings:
+    """Parse a local review markdown document into a ``ReviewFindings``.
+
+    Splits the document on its severity-tier sections (``## Tier 1 — Blocking``
+    / ``## Tier 2 — Advisory``) and on the per-finding ``### <ID> — <title>``
+    headings, extracting each finding's reference, issue, remediation block,
+    and touched commit. Severity comes from the enclosing tier section, with
+    the ``**(BLOCKING)**`` heading marker as a corroborating signal.
+    """
+    text = Path(path).read_text()
+    lines = text.splitlines()
+
+    findings: list[ReviewFinding] = []
+    current_severity: Literal["blocking", "advisory"] | None = None
+    pending: tuple[str, str, Literal["blocking", "advisory"]] | None = None
+    body_lines: list[str] = []
+
+    def flush() -> None:
+        nonlocal pending, body_lines
+        if pending is not None:
+            finding_id, rest, severity = pending
+            findings.append(
+                _parse_finding_block(
+                    finding_id, rest, "\n".join(body_lines), severity
+                )
+            )
+        pending = None
+        body_lines = []
+
+    for line in lines:
+        if _TIER_BLOCKING.match(line):
+            flush()
+            current_severity = "blocking"
+            continue
+        if _TIER_ADVISORY.match(line):
+            flush()
+            current_severity = "advisory"
+            continue
+        heading = _FINDING_HEADING.match(line)
+        if heading is not None and current_severity is not None:
+            flush()
+            rest = heading.group("rest")
+            severity: Literal["blocking", "advisory"] = current_severity
+            if _BLOCKING_MARKER in rest:
+                severity = "blocking"
+            pending = (heading.group("id"), rest, severity)
+            continue
+        if line.startswith("## "):
+            # A non-tier section heading (e.g. Cross-cutting decisions) ends
+            # the findings region.
+            flush()
+            current_severity = None
+            continue
+        if pending is not None:
+            body_lines.append(line)
+
+    flush()
+    return ReviewFindings(
+        issue_number=issue_number,
+        iteration=iteration,
+        path=str(path),
+        findings=findings,
+    )
+
+
+def load_review_findings(
+    issue_number: int, iteration: int | None = None
+) -> ReviewFindings:
+    """Load and parse a local review document for ``issue_number``.
+
+    With ``iteration=None`` the latest review round is loaded; with an explicit
+    integer that exact ``review-<iteration>.md`` is loaded. Raises
+    ``ValueError`` with a clear message when the review directory is absent,
+    holds no ``review-*.md``, or the requested explicit iteration's file does
+    not exist.
+    """
+    directory = _reviews_dir(issue_number)
+    if not directory.is_dir():
+        raise ValueError(
+            f"No review documents found for issue #{issue_number}: "
+            f"directory {directory} does not exist. Run sdlc_review on the "
+            "PR first."
+        )
+    if iteration is None:
+        latest = _latest_iteration(issue_number)
+        if latest is None:
+            raise ValueError(
+                f"No review documents found for issue #{issue_number}: "
+                f"{directory} contains no review-<iteration>.md file. Run "
+                "sdlc_review on the PR first."
+            )
+        iteration = latest
+    path = directory / f"review-{iteration}.md"
+    if not path.is_file():
+        available = _iterations(issue_number)
+        raise ValueError(
+            f"Review iteration {iteration} not found for issue "
+            f"#{issue_number}: {path} does not exist. "
+            f"Available iterations: {available or 'none'}."
+        )
+    return parse_review_document(path, issue_number, iteration)
+
+
+def _render_github_findings_as_document(
+    issue_number: int,
+    iteration: int,
+    pr_url: str,
+    threads: list[Finding],
+    body_findings: list[Finding],
+) -> str:
+    """Render GitHub PR ``Finding``s into the local review-document markdown.
+
+    Produces a template-shaped document — header, blocking/advisory tiers, and
+    one finding per GitHub comment — so it can be parsed back by
+    ``parse_review_document``. GitHub review feedback carries no severity, so
+    every converted finding lands in the blocking tier with a generic,
+    pre-selected ``[x]`` "address the reviewer's comment" remediation plus an
+    ``Other:`` slot.
+    """
+    all_findings = [*threads, *body_findings]
+    header = [
+        f"# PR Review (converted) — Round {iteration}",
+        "",
+        f"Generated by converting the GitHub review feedback on {pr_url} "
+        f"(Closes #{issue_number}) into a local review document. GitHub "
+        "review comments carry no severity tier, so each is recorded as a "
+        "blocking finding with a generic pre-selected remediation; adjust "
+        "before applying.",
+        "",
+        "---",
+        "",
+        "## Tier 1 — Blocking",
+        "",
+    ]
+    other_slot = "- [ ] Other: ________________________________________________"
+    blocks: list[str] = []
+    for index, finding in enumerate(all_findings, start=1):
+        if finding.path is not None and finding.line is not None:
+            reference = f"`{finding.path}:{finding.line}`"
+        elif finding.path is not None:
+            reference = f"`{finding.path}`"
+        else:
+            reference = "(cross-cutting — no single line)"
+        author = finding.author or "unknown"
+        title = finding.body.strip().splitlines()[0] if finding.body.strip() else (
+            "Review comment"
+        )
+        blocks.append(
+            "\n".join(
+                [
+                    f"### C{index} — {title} **(BLOCKING)** — @{author}",
+                    f"**Reference:** {reference}",
+                    "",
+                    f"**Issue:** @{author} ({finding.kind}): {finding.body.strip()}",
+                    "",
+                    "**Remediation:**",
+                    "- [x] Address the reviewer's comment. "
+                    "*(Recommended — pre-selected from the GitHub review.)*",
+                    other_slot,
+                    "",
+                ]
+            )
+        )
+    if not blocks:
+        blocks.append(
+            "_No unresolved GitHub review feedback was found on this PR._\n"
+        )
+    advisory = ["---", "", "## Tier 2 — Advisory", ""]
+    return "\n".join(header) + "\n\n---\n\n".join(blocks) + "\n\n" + "\n".join(
+        advisory
+    )
+
+
+def convert_pr_review_to_document(
+    pr_url: str, repo: _Repo | None = None
+) -> ReviewFindings:
+    """Convert a GitHub PR's review feedback into a new local review document.
+
+    Parses ``owner/repo/pr_number`` from ``pr_url`` (which MUST be a GitHub PR
+    URL), fetches the PR's unresolved review threads and non-empty review-body
+    comments, resolves the closing issue, renders the GitHub findings into a
+    template-shaped markdown document at the NEXT iteration (never overwriting),
+    writes it, then parses it back and returns the result.
+
+    Raises ``ValueError`` when ``pr_url`` is not a GitHub PR URL, or when the
+    PR has no closing issue (there is no issue directory to write under).
+    """
+    match = _PR_URL.search(pr_url)
+    if match is None:
+        raise ValueError(
+            f"--review {pr_url!r} is not a GitHub PR URL "
+            "(expected …github.com/<owner>/<repo>/pull/<number>)."
+        )
+    pr_number = int(match.group("number"))
+    if repo is None:
+        repo = resolve_repo()
+    issue_number = _find_closing_issue(repo, pr_number)
+    if issue_number is None:
+        raise ValueError(
+            f"PR {pr_url} closes no issue (no closingIssuesReferences entry "
+            "and no Closes/Fixes/Resolves keyword in the body); cannot place a "
+            "review document under .sdlc/reviews/issue-#<N>/."
+        )
+    threads, body_findings = _query_review_state(repo, pr_number)
+    iteration = _next_iteration(issue_number)
+    document = _render_github_findings_as_document(
+        issue_number, iteration, pr_url, threads, body_findings
+    )
+    directory = _reviews_dir(issue_number)
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"review-{iteration}.md"
+    path.write_text(document)
+    return parse_review_document(path, issue_number, iteration)
 
 
 def _classify_number(
@@ -283,29 +734,84 @@ def _query_review_state(
     return threads, body_findings
 
 
-def dispatch(number: int, repo: _Repo | None = None) -> Findings | PrContext | None:
-    """Classify ``number`` and gather PR feedback if applicable.
+def dispatch(
+    number: int,
+    repo: _Repo | None = None,
+    review: int | str | None = None,
+) -> ReviewFindings | PrContext | None:
+    """Classify ``number`` and resolve the review work to perform.
+
+    The ``review`` argument is polymorphic and selects the finding source:
+
+    * ``int`` — load that explicit local review iteration for the closing
+      issue. A missing iteration raises ``ValueError``.
+    * ``str`` — a GitHub PR URL whose review feedback is converted into a NEW
+      local review document (at the next iteration) and returned. A
+      non-PR-URL string raises ``ValueError``.
+    * ``None`` (the default) — load the latest local review document for the
+      closing issue when one exists; otherwise preserve the legacy
+      classification: a linked PR with no local docs yields ``PrContext``
+      (continue flow) and a bare issue with no PR yields ``None`` (fresh flow).
 
     Args:
       number: An issue number or an open PR number.
       repo: A pre-resolved target repository. When ``None`` (the default),
-        the repo is resolved via ``resolve_repo()``. Callers that already
-        resolved the repo (e.g. to build the target-repo directive) SHOULD
-        pass it to avoid a redundant ``gh repo view`` round-trip.
+        the repo is resolved via ``resolve_repo()`` — but only if a ``gh``
+        round-trip is actually needed; a local-doc lookup for a bare issue
+        with ``review`` ``None``/``int`` needs no ``gh``.
+      review: The review-feedback selector described above.
 
     Returns:
-      * ``None`` — ``number`` is an issue with no linked PR (fresh flow).
-      * ``PrContext`` — a PR is in scope but has no unresolved feedback (continue flow).
-      * ``Findings`` — a PR is in scope with unresolved feedback (feedback flow).
+      * ``None`` — fresh-implementation flow.
+      * ``PrContext`` — continue flow (a PR is in scope, no local review docs).
+      * ``ReviewFindings`` — feedback flow, sourced from a local review document
+        (or a freshly converted PR-URL document).
 
-    Raises ``GhUnavailable`` for any error, including ``number`` not being
-    a known issue or PR in the target repo.
+    Raises ``GhUnavailable`` for any ``gh`` error (including ``number`` not
+    being a known issue or PR), and ``ValueError`` for a missing requested
+    iteration or a malformed PR-URL ``review`` argument.
     """
+    # A PR-URL conversion is independent of ``number``'s classification.
+    if isinstance(review, str):
+        if repo is None:
+            repo = resolve_repo()
+        return convert_pr_review_to_document(review, repo)
+
+    # Local docs need no ``gh``. ``number`` IS the closing issue when it names
+    # an issue, so speculatively try a local lookup keyed on it before paying
+    # for classification. A hit returns immediately; a miss falls through and
+    # the ``gh`` classification below tells us whether it was a PR after all.
+    local = _try_local_review(number, review)
+    if local is not None:
+        return local
+
     if repo is None:
         repo = resolve_repo()
     kind, pr_meta = _classify_number(repo, number)
     if kind == "missing":
         raise GhUnavailable(f"#{number} is neither an open issue nor a PR")
+
+    if kind == "issue":
+        issue_number: int | None = number
+    else:
+        issue_number = _find_closing_issue(repo, number)
+
+    if review is not None:
+        if issue_number is None:
+            raise ValueError(
+                f"--review {review} was requested for PR #{number}, but the "
+                "PR closes no issue, so there is no .sdlc/reviews/issue-#<N>/ "
+                "directory to read review documents from."
+            )
+        # ``number`` was a PR whose closing issue we only just resolved; retry
+        # the local lookup against it, surfacing a missing iteration clearly.
+        return load_review_findings(issue_number, review)
+
+    if issue_number is not None:
+        local = _try_local_review(issue_number, None)
+        if local is not None:
+            return local
+
     if kind == "issue":
         pr_meta = _find_linked_pr(repo, number)
         if pr_meta is None:
@@ -314,13 +820,31 @@ def dispatch(number: int, repo: _Repo | None = None) -> Findings | PrContext | N
     pr_number = int(pr_meta["number"])
     head_ref = pr_meta["headRefName"]
     url = pr_meta["url"]
-    threads, body_findings = _query_review_state(repo, pr_number)
-    findings = [*threads, *body_findings]
-    if not findings:
-        return PrContext(pr_number=pr_number, head_ref=head_ref, url=url)
-    return Findings(
-        pr_number=pr_number, head_ref=head_ref, url=url, findings=findings
-    )
+    return PrContext(pr_number=pr_number, head_ref=head_ref, url=url)
+
+
+def _try_local_review(
+    issue_number: int, iteration: int | None
+) -> ReviewFindings | None:
+    """Return the local review document for ``issue_number`` if present.
+
+    Returns ``None`` (rather than raising) when the directory or the requested
+    iteration is absent, so callers can fall through to a ``gh``-based path.
+    """
+    directory = _reviews_dir(issue_number)
+    if not directory.is_dir():
+        return None
+    if iteration is None:
+        latest = _latest_iteration(issue_number)
+        if latest is None:
+            return None
+        return parse_review_document(
+            directory / f"review-{latest}.md", issue_number, latest
+        )
+    path = directory / f"review-{iteration}.md"
+    if not path.is_file():
+        return None
+    return parse_review_document(path, issue_number, iteration)
 
 
 def closing_issue(pr_number: int) -> int | None:

--- a/src/sdlc/server.py
+++ b/src/sdlc/server.py
@@ -125,18 +125,21 @@ async def sdlc_issue(
 
 
 @mcp.tool()
-async def sdlc_implement(number: int, target: str | None = None) -> str:
-    """Implement a GitHub issue or address feedback on an open PR.
+async def sdlc_implement(
+    number: int, target: str | None = None, review: int | str | None = None
+) -> str:
+    """Implement a GitHub issue or address local review feedback on a PR.
 
     Use when the user says "implement", "implement #N", or similar.
     Pass an issue number for a fresh start; pass a PR number to continue
-    work on an in-progress PR or to address unresolved review feedback.
+    work on an in-progress PR or to address review feedback.
 
-    The endpoint inspects the GitHub state for ``number`` and returns one
-    of three skill prompts: the fresh-implementation prompt, the
-    continue-on-existing-branch prompt, or the PR-feedback-remediation
-    prompt. If ``gh`` is unavailable, falls back to the fresh prompt with
-    a diagnostic note.
+    The endpoint inspects the GitHub state for ``number`` and the ``review``
+    selector, then returns one of three skill prompts: the fresh-implementation
+    prompt, the continue-on-existing-branch prompt, or the feedback-remediation
+    prompt sourced from a local review document under
+    ``.sdlc/reviews/issue-#<N>/``. If ``gh`` is unavailable, falls back to the
+    fresh prompt with a diagnostic note.
 
     Args:
         number: An issue number or an open PR number.
@@ -144,6 +147,15 @@ async def sdlc_implement(number: int, target: str | None = None) -> str:
             a fresh implementation creates its branch from this branch instead
             of the repo default. Ignored on the continue and feedback paths,
             which operate on an existing branch.
+        review: Polymorphic review-feedback selector.
+            * ``None`` (default) — load the latest local review document for
+              the closing issue when one exists; otherwise route to the
+              continue (linked PR) or fresh (bare issue) prompt.
+            * ``int`` — load that exact local review iteration. A missing
+              iteration returns a clear diagnostic string.
+            * ``str`` — a GitHub PR URL whose review feedback is converted into
+              a new local review document (next iteration) and consumed. A
+              non-PR-URL string returns a clear diagnostic string.
     """
     try:
         repo = pr_state.resolve_repo()
@@ -153,7 +165,7 @@ async def sdlc_implement(number: int, target: str | None = None) -> str:
         f"\n\n{_target_repo_directive(repo)}" if repo is not None else ""
     )
     try:
-        state = pr_state.dispatch(number, repo=repo)
+        state = pr_state.dispatch(number, repo=repo, review=review)
     except pr_state.GhUnavailable as exc:
         skill = _read_skill("implement")
         parts = [
@@ -165,6 +177,11 @@ async def sdlc_implement(number: int, target: str | None = None) -> str:
             parts.append(f"\n{_target_branch_directive(target)}")
         parts.append(repo_suffix)
         return "".join(parts)
+    except ValueError as exc:
+        return (
+            f"Could not load the requested review feedback for #{number}: "
+            f"{exc}"
+        )
     if state is None:
         skill = _read_skill("implement")
         parts = [f"{skill}\n---\n\nTarget issue: #{number}"]
@@ -172,7 +189,7 @@ async def sdlc_implement(number: int, target: str | None = None) -> str:
             parts.append(f"\n{_target_branch_directive(target)}")
         parts.append(repo_suffix)
         return "".join(parts)
-    if isinstance(state, pr_state.Findings):
+    if isinstance(state, pr_state.ReviewFindings):
         skill = _read_skill("implement-feedback")
         return f"{skill}\n---\n\nTarget: #{number}\n{state.format()}{repo_suffix}"
     skill = _read_skill("implement-continue")

--- a/src/sdlc/skills/implement-continue.md
+++ b/src/sdlc/skills/implement-continue.md
@@ -1,12 +1,12 @@
 ---
 name: implement-continue
 description: >
-  Continue an in-progress GitHub PR that has no review feedback yet.
-  Invoked by the `sdlc_implement` MCP endpoint when a PR is in scope and
-  has zero unresolved review threads and zero non-empty review-body
-  comments. Checks out the PR branch, identifies remaining work against
-  the linked issue, and enters planning phase to design the next slice
-  of execution.
+  Continue an in-progress GitHub PR that has no local review document yet.
+  Invoked by the `sdlc_implement` MCP endpoint when a PR is in scope and no
+  `.sdlc/reviews/issue-#<N>/review-<iteration>.md` exists for its closing
+  issue. Checks out the PR branch, identifies remaining work against the
+  linked issue, and enters planning phase to design the next slice of
+  execution.
 subagent:
   support: optional
   type: general-purpose
@@ -24,7 +24,7 @@ Pick up an in-progress PR that has no review feedback yet. Check out the PR bran
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when a PR is in scope but has zero unresolved review threads and zero non-empty review-body comments. Fresh-start work is routed to the `implement` skill; PR review feedback is routed to the `implement-feedback` skill.
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state and the `--review` selector — this skill is returned when a PR is in scope but no local review document exists for its closing issue (and none was requested via `--review`). Fresh-start work is routed to the `implement` skill; a selected local review document's findings are routed to the `implement-feedback` skill.
 
 ## Implementation Notes
 

--- a/src/sdlc/skills/implement-feedback.md
+++ b/src/sdlc/skills/implement-feedback.md
@@ -1,11 +1,13 @@
 ---
 name: implement-feedback
 description: >
-  Address unresolved PR review feedback for an open pull request.
-  Invoked by the `sdlc_implement` MCP endpoint when an open PR has
-  unresolved review threads or non-empty review-body comments. Walks
-  through findings sequentially with per-finding evaluation, approval,
-  and fixup-commit guidance.
+  Address the findings recorded in a local review document for an open
+  pull request. Invoked by the `sdlc_implement` MCP endpoint when a local
+  `.sdlc/reviews/issue-#<N>/review-<iteration>.md` document is selected —
+  the latest iteration by default, an explicit `--review <int>` iteration,
+  or a document freshly converted from a `--review <pr-url>`. Walks through
+  findings sequentially with per-finding evaluation, approval, and
+  fixup-commit guidance.
 subagent:
   support: optional
   type: general-purpose
@@ -20,11 +22,11 @@ The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RE
 
 # Implement Feedback Skill
 
-Walk through unresolved PR review feedback systematically, one finding at a time, with per-finding evaluation and approval gates. Generate ready-to-execute fixup-commit commands after each remediation; do not auto-commit.
+Walk through the findings in a local review document systematically, one finding at a time, with per-finding evaluation and approval gates. Generate ready-to-execute fixup-commit commands after each remediation; do not auto-commit.
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when an open PR has unresolved review threads or non-empty review-body comments. Fresh-start work is routed to the `implement` skill; mid-implementation continuation is routed to the `implement-continue` skill.
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state and the `--review` selector — this skill is returned when a local review document is selected: the latest `.sdlc/reviews/issue-#<N>/review-<iteration>.md` for the closing issue (the default when one exists), an explicit `--review <int>` iteration, or a document just converted from a `--review <pr-url>`. Fresh-start work is routed to the `implement` skill; mid-implementation continuation with no local review document is routed to the `implement-continue` skill.
 
 ## Implementation Notes
 
@@ -32,10 +34,10 @@ This skill does **not** use the structured planning interface (`EnterPlanMode` f
 
 ## Invariants
 
-- MUST verify the server-supplied finding enumeration by re-querying both review threads AND review-body comments before walking through findings.
-- MUST order findings by the canonical severity sequence (correctness → code quality → integration tests → unit tests → style → docs).
+- MUST verify the server-supplied finding enumeration by re-reading the LOCAL review document the endpoint named before walking through findings.
+- MUST order findings by the canonical severity sequence (correctness → code quality → integration tests → unit tests → style → docs), within which the document's own blocking-before-advisory tiering is honored.
 - MUST track findings as a todo list, one task per finding, kept visible to the user.
-- MUST present findings sequentially. For each finding the agent MUST restate the finding with `file:line` citation, evaluate correctness/relevance, propose one or more solutions with their implications, recommend one option, and wait for explicit user approval before editing.
+- MUST present findings sequentially. For each finding the agent MUST restate the finding with its `Reference` (which may be `file:line`, a whole-file path, or an issue-level reference), evaluate correctness/relevance, present the document's pre-selected `[x]` remediation as the recommended option (alongside any alternatives), and wait for explicit user approval before editing.
 - MUST NOT auto-commit. After each approved remediation, MUST emit a copy-paste-able `git commit --fixup=<sha>` block mapping each touched file back to the commit on the branch that owns that surface. The agent MUST NOT execute these commands.
 - MUST prompt the user to run `sdlc_commit` when they are ready to commit the accumulated remediations.
 - MUST NOT proceed to the next pipeline step autonomously.
@@ -43,7 +45,7 @@ This skill does **not** use the structured planning interface (`EnterPlanMode` f
 
 ## Arguments
 
-The MCP endpoint supplies the PR number, branch name, PR URL, and an enumerated list of findings (review threads and review-body comments) appended below this skill prompt. The agent MUST treat that enumeration as a starting point and re-query (step 3) to confirm completeness before walking through findings. The endpoint also appends a `Target repo: <id>` directive identifying the repository for `gh` commands that reference issues or PRs (the upstream `<owner>/<name>` when the current repo is a fork, otherwise the current repo); consume it in step 1 rather than re-deriving the target repo.
+The MCP endpoint supplies a rendered review-document block appended below this skill prompt. The block carries the source document path (`.sdlc/reviews/issue-#<N>/review-<iteration>.md`), the issue number, the iteration, and the enumerated findings — each with its id, severity, `Reference`, title, issue, and pre-selected remediation, ordered blocking before advisory. The document was selected by the `--review` argument: the latest iteration by default, an explicit `--review <int>` iteration, or a document just converted from a `--review <pr-url>` (in which case each finding carries a generic pre-selected "address the reviewer's comment" remediation that the user disambiguates per finding). The agent MUST treat the rendered block as a starting point and re-read the named local document (step 3) to confirm completeness before walking through findings. The endpoint also appends a `Target repo: <id>` directive identifying the repository for `gh` commands that reference issues or PRs (the upstream `<owner>/<name>` when the current repo is a fork, otherwise the current repo); consume it in step 1 rather than re-deriving the target repo.
 
 ## Subagent Execution (Optional)
 
@@ -86,42 +88,38 @@ All `gh` commands in subsequent steps that reference issues or PRs MUST include 
 
 ### 2. Check out the PR branch
 
-The MCP endpoint supplied the branch name. Fetch and check it out:
+The appended block names the closing issue `#<N>` but not the PR branch, so resolve the PR that closes `#<N>` and check out its head branch. Find the linked PR and read its head ref:
+
+```bash
+gh pr list --repo <target> --search "Closes #<N>" --json number,headRefName --jq '.[0]'
+```
+
+(Omit `--repo <target>` when the target is the current repo, per step 1.)
+
+Then fetch and check out that branch:
 
 ```bash
 git fetch origin <branch> && git checkout <branch>
 ```
 
-If the working tree has uncommitted changes that would conflict with the checkout, stop and ask the user how to proceed.
+If the working tree has uncommitted changes that would conflict with the checkout, stop and ask the user how to proceed. If no open PR closes `#<N>` (the review document predates the PR being reopened, or the branch was deleted), stop and ask the user which branch to work on.
 
 ### 3. Verify findings
 
-The server-supplied enumeration is the starting point but MUST be verified. Re-query both surfaces:
+The server-supplied enumeration is the starting point but MUST be verified against its source — the LOCAL review document named in the appended block. Read it in full:
 
 ```bash
-gh api graphql -f query='
-  query($owner: String!, $repo: String!, $pr: Int!) {
-    repository(owner: $owner, name: $repo) {
-      pullRequest(number: $pr) {
-        reviewThreads(first: 100) {
-          nodes { isResolved comments(first: 1) { nodes { body path line author { login } } } }
-        }
-      }
-    }
-  }
-' -f owner='<owner>' -f repo='<repo>' -F pr=<pr-number>
-
-gh pr view <pr-number> --repo <target> --json reviews
+cat .sdlc/reviews/issue-#<N>/review-<iteration>.md
 ```
 
-**Definition of "unresolved review comment":** A review comment is unresolved when its thread is literally marked as unresolved in GitHub's review UI (i.e., the thread has not been clicked "Resolve conversation"). This is a binary GitHub state, not a judgment call. Use the `isResolved` field on review-thread nodes to determine this. An unresolved thread means the reviewer intentionally left it open — the skill MUST read each unresolved comment, understand what the reviewer is asking for, and plan changes to address it. Do not dismiss unresolved comments as already handled without verifying the reviewer's intent.
+This is a local artifact `sdlc_review` (or a `--review <pr-url>` conversion) wrote; nothing is re-queried from GitHub. The document is the authoritative finding set for this round — there is no GitHub `isResolved` state to consult, because the review was never posted to GitHub.
 
-Findings come from two surfaces and BOTH MUST be enumerated:
+The findings are recorded in the document under two severity tiers and BOTH MUST be enumerated:
 
-- **Review threads** — inline comments left on specific lines of the diff. The correctness review in particular often carries its findings here rather than in the PR-level review body.
-- **Review-body comments** — PR-level comments left as part of a review summary. Skip empty bodies (an APPROVED review with no body is not a finding).
+- **Tier 1 — Blocking** — defects that MUST be resolved before approval per the raising role's blocking policy.
+- **Tier 2 — Advisory** — clarity, consistency, or quality observations that do not gate approval; the user elects which to fix.
 
-If the verification surfaces findings the server's enumeration missed, add them to the working set. If it surfaces fewer (e.g., a reviewer resolved a thread between the server query and now), drop them.
+Each finding carries a stable id, a `Reference` (a `file:line` citation, a whole-file path, or an issue-level reference for line-less findings), an `Issue` section with evidence, and a `Remediation` checklist whose pre-selected `[x]` option is the consolidator's recommendation. If re-reading the document surfaces findings the rendered block abbreviated or omitted, work from the document — it is the source of truth.
 
 ### 4. Order findings by severity
 
@@ -138,14 +136,14 @@ Sort the verified findings by the canonical severity sequence so downstream reme
 
 ### 5. Track findings as a todo list
 
-Create one task per finding so the user can see progress. The task description SHOULD include the finding's `file:line` citation and a short summary so each task is self-contained when read out of context.
+Create one task per finding so the user can see progress. The task description SHOULD include the finding's id and `Reference` and a short summary so each task is self-contained when read out of context.
 
 ### 6. Gather context
 
 Before walking through findings, MUST read enough of the codebase to evaluate them confidently:
 
 - MUST check whether `.understand-anything/knowledge-graph.json` exists. If it does, MUST use the `understand-chat` skill with a query synthesized from the highest-severity finding to gather architectural context. If the graph does not exist, skip this bullet and continue.
-- MUST read source files referenced in any finding's `file:line` citation.
+- MUST read source files named in any finding's `Reference` (the file in a `file:line` or whole-file reference; the region the issue text points to for an issue-level reference).
 - MUST read existing tests for the affected modules.
 - MUST resolve applicable test guides by calling `sdlc_guides_for` with the candidate or referenced source-file paths and `kind="test"`, then read every returned URI to internalize the relevant testing conventions.
 - MUST read project-level instructions (`AGENTS.md`) for build tooling, documentation style, and architecture context.
@@ -154,10 +152,10 @@ Before walking through findings, MUST read enough of the codebase to evaluate th
 
 For each finding, in severity order:
 
-1. **Restate the finding** with its `file:line` citation, the reviewer's name, and the exact body text. Mark the corresponding todo as in-progress.
-2. **Evaluate correctness/relevance.** Reviewers can be wrong or out of date. Read the code at the cited location. State whether the finding is valid, partially valid, or stale, and explain why.
-3. **Propose one or more solutions** with their implications. Call out a recommended option grounded in the PR's objectives.
-4. **Wait for explicit user approval** before editing. Allow the user to push back, ask clarifying questions, or pick a different option. The agent MUST NOT edit any file before approval is given.
+1. **Restate the finding** with its `Reference` (which may be a `file:line` citation, a whole-file path, or an issue-level reference such as `issue acceptance criterion #3`), its id, and its `Issue` text. Mark the corresponding todo as in-progress.
+2. **Evaluate correctness/relevance.** The consolidated review can be wrong or out of date. Read the code at the cited reference (or, for an issue-level reference, the relevant region). State whether the finding is valid, partially valid, or stale, and explain why.
+3. **Present the document's pre-selected remediation** as the recommended option. The `[x]`-marked option in the finding's `Remediation` checklist is the consolidator's recommendation; surface it as such, list any `[ ]` alternatives and the `Other:` slot, and call out which you would pick grounded in the PR's objectives. For a document converted from a `--review <pr-url>`, the pre-selected remediation is a generic "address the reviewer's comment" — restate the underlying GitHub comment and propose a concrete fix for the user to confirm.
+4. **Wait for explicit user approval** before editing. Allow the user to push back, ask clarifying questions, or pick a different option (including `Other:`). The agent MUST NOT edit any file before approval is given.
 5. **Implement the approved option.** Edit only the files in scope of the approved option.
 6. **Mark the todo complete** after the user confirms the remediation looks right (or after step 8's fixup-command block has been emitted, whichever the user prefers).
 
@@ -194,5 +192,5 @@ DO NOT proceed on your own.
 - **Branch checkout fails (missing remote ref):** Stop and report the situation; the supplied branch name may be stale.
 - **Reviewer's intent is ambiguous:** Ask the user to clarify before proposing solutions; do not guess.
 - **Finding is already addressed by an earlier remediation in this session:** Mark the corresponding todo complete with a note (e.g., "obviated by remediation of finding #1") and move on.
-- **Finding has been resolved in GitHub between the server query and the verification re-query:** Drop the finding from the working set with a note.
+- **Finding is obviated by a newer review iteration:** If a later `review-<iteration>.md` exists that supersedes the selected one, surface the discrepancy and ask the user which iteration to work from; do not silently merge them.
 - **No file owns the touched surface (entirely new code):** A net-new commit is appropriate. Emit `git commit -m "<subject>"` instead of a fixup, with a recommended subject in the conventional-commit style.

--- a/src/sdlc/skills/implement.md
+++ b/src/sdlc/skills/implement.md
@@ -23,7 +23,7 @@ Fetch a GitHub issue, create a branch, gather codebase context, and enter planni
 
 ## Pipeline Context
 
-This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **second** stage. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state — this skill is returned when the supplied number is an issue with no linked PR. PR-based work (continuing an in-progress branch or addressing review feedback) is routed to the `implement-continue` and `implement-feedback` skills respectively.
+This skill is part of the development workflow pipeline: `issue` → `implement` → `test` → `commit` → `pr` → `review`. This skill is the **second** stage. The `sdlc_implement` MCP endpoint dispatches between three sibling prompts based on PR state and the `--review` selector — this skill is returned when the supplied number is an issue with no linked PR and no local review document applies. Continuing an in-progress branch is routed to the `implement-continue` skill; addressing a local review document's findings is routed to the `implement-feedback` skill.
 
 ## Implementation Notes
 

--- a/tests/test_pr_state.py
+++ b/tests/test_pr_state.py
@@ -1,11 +1,95 @@
 """Tests for sdlc.pr_state — gh wrappers and PR-state dispatch."""
 
 import json
+import textwrap
 
 import pytest
 
 from sdlc import pr_state
-from sdlc.pr_state import Finding, Findings, GhUnavailable, PrContext, resolve_repo
+from sdlc.pr_state import (
+    Finding,
+    Findings,
+    GhUnavailable,
+    PrContext,
+    ReviewFinding,
+    ReviewFindings,
+    parse_review_document,
+    resolve_repo,
+)
+
+
+def _review_document(blocking="", advisory=""):
+    """Build a minimal review-document markdown body with the given tiers.
+
+    ``blocking`` and ``advisory`` are pre-rendered finding blocks (already
+    dedented); each is dropped under its severity tier heading.
+    """
+    return textwrap.dedent(
+        """\
+        # PR #42 — Round 1 Review
+
+        Header prose with branch commit map and severity legend.
+
+        ---
+
+        ## Tier 1 — Blocking
+
+        {blocking}
+
+        ## Tier 2 — Advisory
+
+        {advisory}
+
+        ## Cross-cutting decisions
+
+        None.
+        """
+    ).format(blocking=blocking, advisory=advisory)
+
+
+_BLOCKING_FINDING = textwrap.dedent(
+    """\
+    ### B1 — Rename foo to bar **(BLOCKING)** — aie (3/10 aie)
+    **Reference:** `src/sdlc/server.py:64`
+
+    **Issue:** The symbol `foo` should be `bar` because the convention says so.
+
+    **Remediation:**
+    - [x] Rename `foo` to `bar`. *(Recommended — matches the convention.)*
+    - [ ] Leave it and add a comment.
+    - [ ] Other: ________________________________________________
+
+    **Touched commit:** `abc1234`
+    """
+)
+
+_ADVISORY_FINDING = textwrap.dedent(
+    """\
+    ### A1 — Tidy the import block — aie (2/10 aie)
+    **Reference:** `src/sdlc/server.py`
+
+    The imports could be grouped more clearly; this is a readability nit.
+    - [x] Group stdlib imports first. *(Recommended — readability.)*
+    - [ ] Other: ________________________________________________
+
+    **Touched commit:** `def5678`
+    """
+)
+
+_ISSUE_LEVEL_FINDING = textwrap.dedent(
+    """\
+    ### B2 — Acceptance criterion #3 omitted **(BLOCKING)** — aie (1/10 aie)
+    **Reference:** issue acceptance criterion #3
+
+    **Issue:** The PR never implements criterion #3 from the issue.
+
+    **Remediation:**
+    - [x] Implement criterion #3. *(Recommended — required by the issue.)*
+    - [ ] Other: ________________________________________________
+
+    **Touched commit:** `abc1234`
+    """
+)
 
 
 def _make_fake_run_gh(responses):
@@ -125,7 +209,7 @@ def _closing_payload(numbers):
     )
 
 
-def test_dispatch_with_issue_and_no_linked_pr(monkeypatch):
+def test_dispatch_with_issue_and_no_linked_pr(tmp_path, monkeypatch):
     """Test dispatch returns None for a fresh issue with no linked PR.
 
     Given:
@@ -136,6 +220,7 @@ def test_dispatch_with_issue_and_no_linked_pr(monkeypatch):
         It should return None to signal the fresh-implementation flow.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
         ("pr", "view", "99", "--json", "number,headRefName,url"): None,
@@ -154,18 +239,19 @@ def test_dispatch_with_issue_and_no_linked_pr(monkeypatch):
     assert result is None
 
 
-def test_dispatch_with_issue_linked_pr_and_no_feedback(monkeypatch):
-    """Test dispatch returns a PrContext when the linked PR has no feedback.
+def test_dispatch_with_issue_linked_pr_and_no_local_docs(tmp_path, monkeypatch):
+    """Test dispatch returns a PrContext for an issue whose PR has no local docs.
 
     Given:
-        An issue number whose linked PR has zero unresolved review threads
-        and zero non-empty review-body comments.
+        An issue number with no local review document on disk whose linked PR
+        is 42.
     When:
         dispatch(99) is called.
     Then:
-        It should return a PrContext carrying the PR's metadata.
+        It should return a PrContext carrying the linked PR's metadata.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     pr_meta = {
         "number": 42,
         "headRefName": "feature-x",
@@ -179,8 +265,6 @@ def test_dispatch_with_issue_linked_pr_and_no_feedback(monkeypatch):
             "pr", "list", "--search", "Closes #99",
             "--json", "number,headRefName,url", "--jq", ".[0]",
         ): json.dumps(pr_meta),
-        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
-        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
     }
     monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
 
@@ -193,23 +277,24 @@ def test_dispatch_with_issue_linked_pr_and_no_feedback(monkeypatch):
     )
 
 
-def test_dispatch_with_pr_number_and_no_feedback(monkeypatch):
-    """Test dispatch returns a PrContext when a PR number is passed directly.
+def test_dispatch_with_pr_number_and_no_local_docs(tmp_path, monkeypatch):
+    """Test dispatch returns a PrContext for a PR with no local review docs.
 
     Given:
-        Number 42 classifies as a PR with zero unresolved feedback.
+        Number 42 classifies as a PR whose closing issue 7 has no local review
+        document on disk.
     When:
-        dispatch(42) is called.
+        dispatch(42) is called with the default review selector.
     Then:
-        It should return a PrContext carrying the PR's own metadata, with
-        no detour through find_linked_pr.
+        It should return a PrContext carrying the PR's own metadata, with no
+        detour through find_linked_pr.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
         ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
-        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
-        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
     }
     monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
 
@@ -222,17 +307,105 @@ def test_dispatch_with_pr_number_and_no_feedback(monkeypatch):
     )
 
 
-def test_dispatch_with_unresolved_threads(monkeypatch):
-    """Test dispatch returns Findings when a PR has unresolved review threads.
+def test_dispatch_should_load_latest_local_review_for_issue(tmp_path, monkeypatch):
+    """Test dispatch loads the latest local review document for an issue.
 
     Given:
-        A PR with one unresolved and one resolved thread.
+        Issue 7 has a local review-1.md with a blocking finding.
     When:
-        dispatch(42) is called.
+        dispatch(7) is called with the default review selector.
     Then:
-        It should return Findings containing only the unresolved thread.
+        It should return the parsed ReviewFindings without any gh round-trip.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+
+    def fail(args, allow_failure=False):
+        raise AssertionError(f"dispatch should not call gh: {args}")
+
+    monkeypatch.setattr(pr_state, "_run_gh", fail)
+
+    # Act
+    result = pr_state.dispatch(7)
+
+    # Assert
+    assert isinstance(result, ReviewFindings)
+    assert result.issue_number == 7
+    assert result.iteration == 1
+    assert result.findings[0].id == "B1"
+
+
+def test_dispatch_should_load_explicit_iteration_when_review_is_int(
+    tmp_path, monkeypatch
+):
+    """Test dispatch loads the given iteration when review is an int.
+
+    Given:
+        Issue 7 has review-1.md and review-2.md.
+    When:
+        dispatch(7, review=1) is called.
+    Then:
+        It should return the iteration-1 ReviewFindings, not the latest.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+    second = _BLOCKING_FINDING.replace("### B1", "### B2")
+    (directory / "review-2.md").write_text(_review_document(blocking=second))
+
+    # Act
+    result = pr_state.dispatch(7, review=1)
+
+    # Assert
+    assert isinstance(result, ReviewFindings)
+    assert result.iteration == 1
+    assert result.findings[0].id == "B1"
+
+
+def test_dispatch_should_raise_when_explicit_iteration_missing(tmp_path, monkeypatch):
+    """Test dispatch raises ValueError for a missing explicit iteration.
+
+    Given:
+        Issue 7 has only review-1.md.
+    When:
+        dispatch(7, review=9) is called.
+    Then:
+        It should raise ValueError rather than silently falling back.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+    responses = {
+        ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
+        ("pr", "view", "7", "--json", "number,headRefName,url"): None,
+        ("issue", "view", "7"): "issue body",
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+
+    # Act & assert
+    with pytest.raises(ValueError, match="iteration 9 not found"):
+        pr_state.dispatch(7, review=9)
+
+
+def test_dispatch_should_convert_when_review_is_a_pr_url(tmp_path, monkeypatch):
+    """Test dispatch converts a PR URL into a local document when review is a str.
+
+    Given:
+        A GitHub PR URL whose PR closes issue 7 and carries review feedback.
+    When:
+        dispatch with review set to that PR URL is called.
+    Then:
+        It should write and return the converted ReviewFindings.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
     threads = [
         {
             "isResolved": False,
@@ -243,84 +416,48 @@ def test_dispatch_with_unresolved_threads(monkeypatch):
                 "author": {"login": "alice"},
             }]},
         },
-        {
-            "isResolved": True,
-            "comments": {"nodes": [{
-                "body": "ignore me — already fixed",
-                "path": "src/sdlc/guides.py",
-                "line": 10,
-                "author": {"login": "bob"},
-            }]},
-        },
     ]
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
-        ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
         _graphql_args("conradbzura", "sdlc", 42): _graphql_payload(threads),
         ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
     }
     monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
 
     # Act
-    result = pr_state.dispatch(42)
+    result = pr_state.dispatch(
+        42, review="https://github.com/conradbzura/sdlc/pull/42"
+    )
 
     # Assert
-    assert isinstance(result, Findings)
-    assert result.pr_number == 42
-    assert result.head_ref == "feature-x"
-    assert len(result.findings) == 1
-    finding = result.findings[0]
-    assert finding.kind == "review_thread"
-    assert finding.path == "src/sdlc/server.py"
-    assert finding.line == 64
-    assert "rename foo to bar" in finding.body
-    assert finding.author == "alice"
+    assert isinstance(result, ReviewFindings)
+    assert result.issue_number == 7
+    assert (tmp_path / ".sdlc" / "reviews" / "issue-#7" / "review-1.md").is_file()
 
 
-def test_dispatch_with_review_body_comments(monkeypatch):
-    """Test dispatch surfaces non-empty review-body comments alongside threads.
+def test_dispatch_should_raise_for_malformed_pr_url(monkeypatch):
+    """Test dispatch raises ValueError when review is a non-PR-URL string.
 
     Given:
-        A PR with no unresolved threads but one non-empty review body and
-        one empty review body (an APPROVED-only review).
+        A numeric string that is not a GitHub PR URL.
     When:
-        dispatch(42) is called.
+        dispatch(42, review="123") is called.
     Then:
-        It should return Findings containing only the non-empty review-body
-        comment marked with kind="review_body" and no file/line.
+        It should raise ValueError rather than coercing it to an iteration.
     """
     # Arrange
-    reviews = [
-        {
-            "author": {"login": "alice"},
-            "body": "Please address the doc gap.",
-            "state": "COMMENTED",
-        },
-        {"author": {"login": "bob"}, "body": "", "state": "APPROVED"},
-    ]
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
-        ("pr", "view", "42", "--json", "number,headRefName,url"): _PR_VIEW_42,
-        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
-        ("pr", "view", "42", "--json", "reviews"): _reviews_payload(reviews),
     }
     monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
 
-    # Act
-    result = pr_state.dispatch(42)
-
-    # Assert
-    assert isinstance(result, Findings)
-    assert len(result.findings) == 1
-    finding = result.findings[0]
-    assert finding.kind == "review_body"
-    assert finding.path is None
-    assert finding.line is None
-    assert "Please address the doc gap." in finding.body
-    assert finding.author == "alice"
+    # Act & assert
+    with pytest.raises(ValueError, match="not a GitHub PR URL"):
+        pr_state.dispatch(42, review="123")
 
 
-def test_dispatch_with_unknown_number(monkeypatch):
+def test_dispatch_with_unknown_number(tmp_path, monkeypatch):
     """Test dispatch raises when the number does not name an issue or PR.
 
     Given:
@@ -331,6 +468,7 @@ def test_dispatch_with_unknown_number(monkeypatch):
         It should raise GhUnavailable.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_NOT_FORK,
         ("pr", "view", "999", "--json", "number,headRefName,url"): None,
@@ -343,7 +481,7 @@ def test_dispatch_with_unknown_number(monkeypatch):
         pr_state.dispatch(999)
 
 
-def test_dispatch_when_repo_view_fails(monkeypatch):
+def test_dispatch_when_repo_view_fails(tmp_path, monkeypatch):
     """Test dispatch raises GhUnavailable when gh repo view fails.
 
     Given:
@@ -354,6 +492,8 @@ def test_dispatch_when_repo_view_fails(monkeypatch):
         It should raise GhUnavailable.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
+
     def fake(args, allow_failure=False):
         raise GhUnavailable("gh repo view failed (canned)")
 
@@ -364,11 +504,12 @@ def test_dispatch_when_repo_view_fails(monkeypatch):
         pr_state.dispatch(42)
 
 
-def test_dispatch_with_fork_repo(monkeypatch):
+def test_dispatch_with_fork_repo(tmp_path, monkeypatch):
     """Test dispatch routes gh calls to upstream when current repo is a fork.
 
     Given:
-        gh repo view reports the repo is a fork of upstream/sdlc.
+        gh repo view reports the repo is a fork of upstream/sdlc and PR 42
+        closes issue 7 with no local review document.
     When:
         dispatch(42) is called.
     Then:
@@ -376,16 +517,14 @@ def test_dispatch_with_fork_repo(monkeypatch):
         graphql variables should reference the upstream owner/repo.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     responses = {
         ("repo", "view", "--json", _REPO_VIEW_FIELDS): _REPO_FORK,
         (
             "pr", "view", "42", "--repo", "upstream/sdlc",
             "--json", "number,headRefName,url",
         ): _PR_VIEW_42,
-        _graphql_args("upstream", "sdlc", 42): _graphql_payload([]),
-        (
-            "pr", "view", "42", "--repo", "upstream/sdlc", "--json", "reviews",
-        ): _reviews_payload([]),
+        _closing_graphql_args("upstream", "sdlc", 42): _closing_payload([7]),
     }
     monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
 
@@ -700,3 +839,507 @@ class TestFindings:
         assert "alice" in rendered
         assert "None:None" not in rendered
         assert ":None" not in rendered
+
+
+class TestReviewFindings:
+    def test_format_should_render_header_and_finding_details(self):
+        """Test ReviewFindings.format renders the header and each finding.
+
+        Given:
+            ReviewFindings carrying one blocking finding.
+        When:
+            format() is called.
+        Then:
+            The output should include the issue/iteration header and the
+            finding's id, severity, reference, title, and remediation.
+        """
+        # Arrange
+        review = ReviewFindings(
+            issue_number=42,
+            iteration=3,
+            path=".sdlc/reviews/issue-#42/review-3.md",
+            findings=[
+                ReviewFinding(
+                    id="B1",
+                    title="Rename foo to bar",
+                    severity="blocking",
+                    reference="`src/sdlc/server.py:64`",
+                    issue="The symbol foo should be bar.",
+                    remediation="- [x] Rename foo to bar. *(Recommended.)*",
+                    touched_commit="`abc1234`",
+                ),
+            ],
+        )
+
+        # Act
+        rendered = review.format()
+
+        # Assert
+        assert "Issue: #42" in rendered
+        assert "Iteration: 3" in rendered
+        assert "B1" in rendered
+        assert "blocking" in rendered
+        assert "src/sdlc/server.py:64" in rendered
+        assert "Rename foo to bar" in rendered
+        assert "- [x] Rename foo to bar" in rendered
+
+    def test_format_should_order_blocking_findings_before_advisory(self):
+        """Test ReviewFindings.format emits blocking findings before advisory.
+
+        Given:
+            ReviewFindings whose list holds an advisory finding before a
+            blocking one.
+        When:
+            format() is called.
+        Then:
+            The blocking finding should appear before the advisory finding in
+            the rendered output.
+        """
+        # Arrange
+        review = ReviewFindings(
+            issue_number=42,
+            iteration=1,
+            path=".sdlc/reviews/issue-#42/review-1.md",
+            findings=[
+                ReviewFinding(
+                    id="A1",
+                    title="Advisory item",
+                    severity="advisory",
+                    reference="`a.py`",
+                    issue="advisory issue",
+                    remediation="- [x] tidy",
+                    touched_commit=None,
+                ),
+                ReviewFinding(
+                    id="B1",
+                    title="Blocking item",
+                    severity="blocking",
+                    reference="`b.py:1`",
+                    issue="blocking issue",
+                    remediation="- [x] fix",
+                    touched_commit=None,
+                ),
+            ],
+        )
+
+        # Act
+        rendered = review.format()
+
+        # Assert
+        assert rendered.index("Blocking item") < rendered.index("Advisory item")
+
+
+def test_parse_review_document_should_extract_a_blocking_finding(tmp_path):
+    """Test parse_review_document extracts a blocking finding's fields.
+
+    Given:
+        A review document with one blocking finding under Tier 1.
+    When:
+        parse_review_document is called.
+    Then:
+        It should return a ReviewFindings whose finding carries the id, title
+        (with the BLOCKING marker stripped), blocking severity, reference,
+        issue, remediation, and touched commit.
+    """
+    # Arrange
+    path = tmp_path / "review-1.md"
+    path.write_text(_review_document(blocking=_BLOCKING_FINDING))
+
+    # Act
+    result = parse_review_document(path, issue_number=42, iteration=1)
+
+    # Assert
+    assert result.issue_number == 42
+    assert result.iteration == 1
+    assert result.path == str(path)
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.id == "B1"
+    assert finding.title == "Rename foo to bar"
+    assert finding.severity == "blocking"
+    assert finding.reference == "`src/sdlc/server.py:64`"
+    assert "should be `bar`" in finding.issue
+    assert "- [x] Rename `foo` to `bar`." in finding.remediation
+    assert "- [ ] Other:" in finding.remediation
+    assert finding.touched_commit == "`abc1234`"
+
+
+def test_parse_review_document_should_extract_an_advisory_finding(tmp_path):
+    """Test parse_review_document extracts an advisory finding without labels.
+
+    Given:
+        A review document whose Tier 2 advisory finding states its issue as a
+        bare paragraph (no **Issue:** label) and lists its remediation without
+        a **Remediation:** label.
+    When:
+        parse_review_document is called.
+    Then:
+        It should classify the finding as advisory and still capture the bare
+        issue text and the remediation checklist.
+    """
+    # Arrange
+    path = tmp_path / "review-1.md"
+    path.write_text(_review_document(advisory=_ADVISORY_FINDING))
+
+    # Act
+    result = parse_review_document(path, issue_number=42, iteration=1)
+
+    # Assert
+    assert len(result.findings) == 1
+    finding = result.findings[0]
+    assert finding.id == "A1"
+    assert finding.severity == "advisory"
+    assert "readability nit" in finding.issue
+    assert "- [x] Group stdlib imports first." in finding.remediation
+
+
+def test_parse_review_document_should_handle_an_issue_level_reference(tmp_path):
+    """Test parse_review_document preserves a line-less issue-level reference.
+
+    Given:
+        A blocking finding whose Reference is an issue acceptance criterion
+        rather than a file:line citation.
+    When:
+        parse_review_document is called.
+    Then:
+        It should preserve the issue-level reference verbatim.
+    """
+    # Arrange
+    path = tmp_path / "review-1.md"
+    path.write_text(_review_document(blocking=_ISSUE_LEVEL_FINDING))
+
+    # Act
+    result = parse_review_document(path, issue_number=42, iteration=1)
+
+    # Assert
+    finding = result.findings[0]
+    assert finding.reference == "issue acceptance criterion #3"
+    assert finding.severity == "blocking"
+
+
+def test_parse_review_document_should_group_findings_by_tier(tmp_path):
+    """Test parse_review_document assigns severity from the enclosing tier.
+
+    Given:
+        A review document with one finding under each severity tier.
+    When:
+        parse_review_document is called.
+    Then:
+        It should return both findings with the severity of their tier.
+    """
+    # Arrange
+    path = tmp_path / "review-1.md"
+    path.write_text(
+        _review_document(blocking=_BLOCKING_FINDING, advisory=_ADVISORY_FINDING)
+    )
+
+    # Act
+    result = parse_review_document(path, issue_number=42, iteration=1)
+
+    # Assert
+    by_id = {f.id: f.severity for f in result.findings}
+    assert by_id == {"B1": "blocking", "A1": "advisory"}
+
+
+def test_parse_review_document_should_separate_adjacent_findings(tmp_path):
+    """Test parse_review_document splits two findings joined by a separator.
+
+    Given:
+        Two blocking findings under Tier 1 separated by a --- horizontal rule.
+    When:
+        parse_review_document is called.
+    Then:
+        It should return both findings, and neither remediation should absorb
+        the --- separator.
+    """
+    # Arrange
+    second = _BLOCKING_FINDING.replace("### B1", "### B3").replace(
+        "Rename foo to bar", "Tighten the guard"
+    )
+    blocking = f"{_BLOCKING_FINDING}\n---\n\n{second}"
+    path = tmp_path / "review-1.md"
+    path.write_text(_review_document(blocking=blocking))
+
+    # Act
+    result = parse_review_document(path, issue_number=42, iteration=1)
+
+    # Assert
+    assert [f.id for f in result.findings] == ["B1", "B3"]
+    for finding in result.findings:
+        assert "---" not in finding.remediation
+
+
+def test_iterations_should_be_empty_when_no_review_dir(tmp_path, monkeypatch):
+    """Test the iteration helper returns nothing when no review dir exists.
+
+    Given:
+        A working directory with no .sdlc/reviews/issue-#7 directory.
+    When:
+        load_review_findings(7) is called.
+    Then:
+        It should raise ValueError naming the missing directory.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+
+    # Act & assert
+    with pytest.raises(ValueError, match="does not exist"):
+        pr_state.load_review_findings(7)
+
+
+def test_load_review_findings_should_load_the_latest_iteration(tmp_path, monkeypatch):
+    """Test load_review_findings loads the highest iteration when none is given.
+
+    Given:
+        Issue 7 has review-1.md and review-2.md, the latter naming finding B2.
+    When:
+        load_review_findings(7) is called with no explicit iteration.
+    Then:
+        It should load review-2.md (the latest) and report iteration 2.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+    second = _BLOCKING_FINDING.replace("### B1", "### B2")
+    (directory / "review-2.md").write_text(_review_document(blocking=second))
+
+    # Act
+    result = pr_state.load_review_findings(7)
+
+    # Assert
+    assert result.iteration == 2
+    assert result.findings[0].id == "B2"
+
+
+def test_load_review_findings_should_load_an_explicit_iteration(tmp_path, monkeypatch):
+    """Test load_review_findings loads the exact iteration requested.
+
+    Given:
+        Issue 7 has review-1.md and review-2.md.
+    When:
+        load_review_findings(7, iteration=1) is called.
+    Then:
+        It should load review-1.md regardless of the later iteration.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+    second = _BLOCKING_FINDING.replace("### B1", "### B2")
+    (directory / "review-2.md").write_text(_review_document(blocking=second))
+
+    # Act
+    result = pr_state.load_review_findings(7, iteration=1)
+
+    # Assert
+    assert result.iteration == 1
+    assert result.findings[0].id == "B1"
+
+
+def test_load_review_findings_should_raise_when_explicit_iteration_missing(
+    tmp_path, monkeypatch
+):
+    """Test load_review_findings raises when the requested iteration is absent.
+
+    Given:
+        Issue 7 has only review-1.md.
+    When:
+        load_review_findings(7, iteration=5) is called.
+    Then:
+        It should raise ValueError naming the missing iteration.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text(_review_document(blocking=_BLOCKING_FINDING))
+
+    # Act & assert
+    with pytest.raises(ValueError, match="iteration 5 not found"):
+        pr_state.load_review_findings(7, iteration=5)
+
+
+def test_load_review_findings_should_raise_when_dir_has_no_reviews(
+    tmp_path, monkeypatch
+):
+    """Test load_review_findings raises when the dir holds no review files.
+
+    Given:
+        Issue 7's review directory exists but contains no review-<n>.md file.
+    When:
+        load_review_findings(7) is called.
+    Then:
+        It should raise ValueError noting the directory has no review document.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "notes.txt").write_text("not a review")
+
+    # Act & assert
+    with pytest.raises(ValueError, match="no review-<iteration>.md"):
+        pr_state.load_review_findings(7)
+
+
+def test_convert_pr_review_to_document_should_write_and_round_trip(
+    tmp_path, monkeypatch
+):
+    """Test convert_pr_review_to_document writes a doc and parses it back.
+
+    Given:
+        A GitHub PR URL whose review feedback resolves to one thread and one
+        review-body comment, and whose closing issue is 7.
+    When:
+        convert_pr_review_to_document is called.
+    Then:
+        It should write review-1.md under issue-#7 and return ReviewFindings
+        carrying both converted findings.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    threads = [
+        {
+            "isResolved": False,
+            "comments": {"nodes": [{
+                "body": "rename foo to bar",
+                "path": "src/sdlc/server.py",
+                "line": 64,
+                "author": {"login": "alice"},
+            }]},
+        },
+    ]
+    reviews = [{"author": {"login": "bob"}, "body": "Fix the doc gap."}]
+    responses = {
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload(threads),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload(reviews),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+    repo = pr_state._Repo(owner="conradbzura", name="sdlc", repo_flag=None)
+
+    # Act
+    result = pr_state.convert_pr_review_to_document(
+        "https://github.com/conradbzura/sdlc/pull/42", repo=repo
+    )
+
+    # Assert
+    written = tmp_path / ".sdlc" / "reviews" / "issue-#7" / "review-1.md"
+    assert written.is_file()
+    assert result.issue_number == 7
+    assert result.iteration == 1
+    bodies = " ".join(f.issue for f in result.findings)
+    assert "rename foo to bar" in bodies
+    assert "Fix the doc gap." in bodies
+
+
+def test_convert_pr_review_to_document_should_use_the_next_iteration(
+    tmp_path, monkeypatch
+):
+    """Test convert_pr_review_to_document writes the next iteration, never over.
+
+    Given:
+        Issue 7 already has review-1.md, and PR 42 (closing issue 7) has
+        review feedback.
+    When:
+        convert_pr_review_to_document is called.
+    Then:
+        It should write review-2.md and leave review-1.md untouched.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    directory = tmp_path / ".sdlc" / "reviews" / "issue-#7"
+    directory.mkdir(parents=True)
+    (directory / "review-1.md").write_text("existing round one")
+    responses = {
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload([]),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+    repo = pr_state._Repo(owner="conradbzura", name="sdlc", repo_flag=None)
+
+    # Act
+    result = pr_state.convert_pr_review_to_document(
+        "https://github.com/conradbzura/sdlc/pull/42", repo=repo
+    )
+
+    # Assert
+    assert result.iteration == 2
+    assert (directory / "review-2.md").is_file()
+    assert (directory / "review-1.md").read_text() == "existing round one"
+
+
+def test_convert_pr_review_to_document_should_raise_for_non_pr_url(monkeypatch):
+    """Test convert_pr_review_to_document rejects a non-PR-URL argument.
+
+    Given:
+        A string that is not a GitHub PR URL.
+    When:
+        convert_pr_review_to_document is called with it.
+    Then:
+        It should raise ValueError without touching gh.
+    """
+    # Arrange
+    repo = pr_state._Repo(owner="conradbzura", name="sdlc", repo_flag=None)
+
+    # Act & assert
+    with pytest.raises(ValueError, match="not a GitHub PR URL"):
+        pr_state.convert_pr_review_to_document("not-a-url", repo=repo)
+
+
+def test_convert_pr_review_to_document_should_not_leak_separators(
+    tmp_path, monkeypatch
+):
+    """Test the converted document's remediation excludes the tier separator.
+
+    Given:
+        A PR with two review-thread findings whose rendered document separates
+        each finding block with a horizontal rule.
+    When:
+        convert_pr_review_to_document parses the document back.
+    Then:
+        No finding's remediation should capture the trailing --- separator.
+    """
+    # Arrange
+    monkeypatch.chdir(tmp_path)
+    threads = [
+        {
+            "isResolved": False,
+            "comments": {"nodes": [{
+                "body": "first comment",
+                "path": "a.py",
+                "line": 1,
+                "author": {"login": "alice"},
+            }]},
+        },
+        {
+            "isResolved": False,
+            "comments": {"nodes": [{
+                "body": "second comment",
+                "path": "b.py",
+                "line": 2,
+                "author": {"login": "bob"},
+            }]},
+        },
+    ]
+    responses = {
+        _closing_graphql_args("conradbzura", "sdlc", 42): _closing_payload([7]),
+        _graphql_args("conradbzura", "sdlc", 42): _graphql_payload(threads),
+        ("pr", "view", "42", "--json", "reviews"): _reviews_payload([]),
+    }
+    monkeypatch.setattr(pr_state, "_run_gh", _make_fake_run_gh(responses))
+    repo = pr_state._Repo(owner="conradbzura", name="sdlc", repo_flag=None)
+
+    # Act
+    result = pr_state.convert_pr_review_to_document(
+        "https://github.com/conradbzura/sdlc/pull/42", repo=repo
+    )
+
+    # Assert
+    assert len(result.findings) == 2
+    for finding in result.findings:
+        assert "---" not in finding.remediation

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,7 +5,12 @@ import json
 import pytest
 
 from sdlc import pr_state
-from sdlc.pr_state import Finding, Findings, GhUnavailable, PrContext
+from sdlc.pr_state import (
+    GhUnavailable,
+    PrContext,
+    ReviewFinding,
+    ReviewFindings,
+)
 from sdlc.server import (
     agents_md,
     get_default_config,
@@ -161,7 +166,7 @@ async def test_sdlc_implement_with_no_pr(monkeypatch):
         It should return the fresh implement skill with #42 appended.
     """
     # Arrange
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: None)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: None)
 
     # Act
     result = await sdlc_implement(number=42)
@@ -186,7 +191,7 @@ async def test_sdlc_implement_with_no_feedback_pr(monkeypatch):
     """
     # Arrange
     context = PrContext(pr_number=42, head_ref="feature-x", url="https://example/pr/42")
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: context)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: context)
 
     # Act
     result = await sdlc_implement(number=42)
@@ -198,32 +203,36 @@ async def test_sdlc_implement_with_no_feedback_pr(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_sdlc_implement_with_findings(monkeypatch):
-    """Test sdlc_implement returns the feedback skill when findings exist.
+async def test_sdlc_implement_with_review_findings(monkeypatch):
+    """Test sdlc_implement returns the feedback skill when review findings exist.
 
     Given:
-        pr_state.dispatch returns a Findings instance for the given number.
+        pr_state.dispatch returns a ReviewFindings instance for the number.
     When:
         sdlc_implement(number=42) is called.
     Then:
-        It should return the feedback skill with formatted findings appended.
+        It should return the feedback skill with the rendered review document.
     """
     # Arrange
-    findings = Findings(
-        pr_number=42,
-        head_ref="feature-x",
-        url="https://example/pr/42",
+    review_findings = ReviewFindings(
+        issue_number=7,
+        iteration=2,
+        path=".sdlc/reviews/issue-#7/review-2.md",
         findings=[
-            Finding(
-                kind="review_thread",
-                path="src/sdlc/server.py",
-                line=64,
-                body="rename foo to bar",
-                author="alice",
+            ReviewFinding(
+                id="B1",
+                title="Rename foo to bar",
+                severity="blocking",
+                reference="`src/sdlc/server.py:64`",
+                issue="The symbol foo should be bar.",
+                remediation="- [x] Rename foo to bar. *(Recommended.)*",
+                touched_commit="`abc1234`",
             ),
         ],
     )
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: findings)
+    monkeypatch.setattr(
+        pr_state, "dispatch", lambda number, repo=None, review=None: review_findings
+    )
 
     # Act
     result = await sdlc_implement(number=42)
@@ -231,17 +240,98 @@ async def test_sdlc_implement_with_findings(monkeypatch):
     # Assert
     assert "# Implement Feedback Skill" in result
     assert "src/sdlc/server.py:64" in result
-    assert "rename foo to bar" in result
+    assert "Rename foo to bar" in result
+    assert "Iteration: 2" in result
 
 
 @pytest.mark.asyncio
-async def test_sdlc_implement_should_resolve_repo_exactly_once(monkeypatch):
+async def test_sdlc_implement_should_thread_int_review_to_dispatch(monkeypatch):
+    """Test sdlc_implement passes an int review selector through to dispatch.
+
+    Given:
+        A captured dispatch spy and review=3.
+    When:
+        sdlc_implement(number=7, review=3) is called.
+    Then:
+        dispatch should receive review=3.
+    """
+    # Arrange
+    captured = {}
+
+    def fake_dispatch(number, repo=None, review=None):
+        captured["review"] = review
+        return None
+
+    monkeypatch.setattr(pr_state, "dispatch", fake_dispatch)
+
+    # Act
+    await sdlc_implement(number=7, review=3)
+
+    # Assert
+    assert captured["review"] == 3
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_should_thread_pr_url_review_to_dispatch(monkeypatch):
+    """Test sdlc_implement passes a PR-URL review selector through to dispatch.
+
+    Given:
+        A captured dispatch spy and a PR-URL review argument.
+    When:
+        sdlc_implement(number=7, review=<pr-url>) is called.
+    Then:
+        dispatch should receive the PR URL unchanged.
+    """
+    # Arrange
+    captured = {}
+    url = "https://github.com/conradbzura/sdlc/pull/42"
+
+    def fake_dispatch(number, repo=None, review=None):
+        captured["review"] = review
+        return None
+
+    monkeypatch.setattr(pr_state, "dispatch", fake_dispatch)
+
+    # Act
+    await sdlc_implement(number=7, review=url)
+
+    # Assert
+    assert captured["review"] == url
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_should_report_missing_iteration(monkeypatch):
+    """Test sdlc_implement returns a diagnostic when dispatch raises ValueError.
+
+    Given:
+        pr_state.dispatch raises ValueError for a missing review iteration.
+    When:
+        sdlc_implement(number=7, review=9) is called.
+    Then:
+        It should return a clear diagnostic string rather than propagating.
+    """
+    # Arrange
+    def raise_value_error(number, repo=None, review=None):
+        raise ValueError("Review iteration 9 not found for issue #7")
+
+    monkeypatch.setattr(pr_state, "dispatch", raise_value_error)
+
+    # Act
+    result = await sdlc_implement(number=7, review=9)
+
+    # Assert
+    assert "Could not load the requested review feedback" in result
+    assert "iteration 9 not found" in result
+
+
+@pytest.mark.asyncio
+async def test_sdlc_implement_should_resolve_repo_exactly_once(tmp_path, monkeypatch):
     """Test sdlc_implement resolves the target repo exactly once per call.
 
     Given:
-        A non-fork repo and a PR number with no unresolved feedback, with the
-        real dispatch running against a canned gh and a counting spy wrapping
-        resolve_repo.
+        A non-fork repo and a PR number whose closing issue has no local review
+        document, with the real dispatch running against a canned gh and a
+        counting spy wrapping resolve_repo.
     When:
         sdlc_implement(number=42) is called.
     Then:
@@ -250,6 +340,7 @@ async def test_sdlc_implement_should_resolve_repo_exactly_once(monkeypatch):
         classification.
     """
     # Arrange
+    monkeypatch.chdir(tmp_path)
     call_count = 0
 
     def counting_resolve_repo():
@@ -260,30 +351,31 @@ async def test_sdlc_implement_should_resolve_repo_exactly_once(monkeypatch):
     pr_view = json.dumps(
         {"number": 42, "headRefName": "feature-x", "url": "https://example/pr/42"}
     )
-    graphql_query = (
+    closing_query = (
         "query=query($owner: String!, $repo: String!, $pr: Int!) "
         "{ repository(owner: $owner, name: $repo) { pullRequest(number: $pr) "
-        "{ reviewThreads(first: 100) { nodes { isResolved comments(first: 1) "
-        "{ nodes { body path line author { login } } } } } } } }"
+        "{ closingIssuesReferences(first: 10) { nodes { number } } } } }"
+    )
+    closing_payload = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "closingIssuesReferences": {"nodes": [{"number": 7}]}
+                    }
+                }
+            }
+        }
     )
     responses = {
         ("pr", "view", "42", "--json", "number,headRefName,url"): pr_view,
         (
             "api", "graphql",
-            "-f", graphql_query,
+            "-f", closing_query,
             "-f", "owner=conradbzura",
             "-f", "repo=sdlc",
             "-F", "pr=42",
-        ): json.dumps(
-            {
-                "data": {
-                    "repository": {
-                        "pullRequest": {"reviewThreads": {"nodes": []}}
-                    }
-                }
-            }
-        ),
-        ("pr", "view", "42", "--json", "reviews"): json.dumps({"reviews": []}),
+        ): closing_payload,
     }
 
     def fake_run_gh(args, allow_failure=False):
@@ -312,7 +404,7 @@ async def test_sdlc_implement_when_gh_unavailable(monkeypatch):
         It should return the fresh skill with a diagnostic comment appended.
     """
     # Arrange
-    def raise_unavailable(_number, repo=None):
+    def raise_unavailable(_number, repo=None, review=None):
         raise GhUnavailable("gh executable not found on PATH")
 
     monkeypatch.setattr(pr_state, "dispatch", raise_unavailable)
@@ -338,7 +430,7 @@ async def test_sdlc_implement_should_omit_target_directive_when_no_target(monkey
         It should return fresh implement skill content without an override directive.
     """
     # Arrange
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: None)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: None)
 
     # Act
     result = await sdlc_implement(number=42)
@@ -359,7 +451,7 @@ async def test_sdlc_implement_should_append_target_directive_when_target_given(m
         It should return content with the override directive naming "stable".
     """
     # Arrange
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: None)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: None)
 
     # Act
     result = await sdlc_implement(number=42, target="stable")
@@ -768,7 +860,7 @@ async def test_sdlc_implement_should_inject_upstream_target_repo_when_fork(monke
         It should append a "Target repo: upstream/sdlc" directive.
     """
     # Arrange
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: None)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: None)
     _patch_resolve_repo(monkeypatch, _fork_repo())
 
     # Act
@@ -791,7 +883,7 @@ async def test_sdlc_implement_should_inject_target_repo_on_continue_path(monkeyp
     """
     # Arrange
     context = PrContext(pr_number=42, head_ref="feature-x", url="https://example/pr/42")
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: context)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: context)
     _patch_resolve_repo(monkeypatch, _fork_repo())
 
     # Act
@@ -807,28 +899,32 @@ async def test_sdlc_implement_should_inject_target_repo_on_feedback_path(monkeyp
     """Test sdlc_implement injects the target-repo directive on the feedback path.
 
     Given:
-        pr_state.dispatch returns Findings and resolve_repo reports a fork.
+        pr_state.dispatch returns ReviewFindings and resolve_repo reports a fork.
     When:
         sdlc_implement(number=42) is called.
     Then:
         It should append the target-repo directive alongside the findings.
     """
     # Arrange
-    findings = Findings(
-        pr_number=42,
-        head_ref="feature-x",
-        url="https://example/pr/42",
+    review_findings = ReviewFindings(
+        issue_number=7,
+        iteration=1,
+        path=".sdlc/reviews/issue-#7/review-1.md",
         findings=[
-            Finding(
-                kind="review_thread",
-                path="src/sdlc/server.py",
-                line=64,
-                body="rename foo to bar",
-                author="alice",
+            ReviewFinding(
+                id="B1",
+                title="Rename foo to bar",
+                severity="blocking",
+                reference="`src/sdlc/server.py:64`",
+                issue="The symbol foo should be bar.",
+                remediation="- [x] Rename foo to bar.",
+                touched_commit="`abc1234`",
             ),
         ],
     )
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: findings)
+    monkeypatch.setattr(
+        pr_state, "dispatch", lambda number, repo=None, review=None: review_findings
+    )
     _patch_resolve_repo(monkeypatch, _fork_repo())
 
     # Act
@@ -852,7 +948,7 @@ async def test_sdlc_implement_should_inject_target_repo_when_gh_state_unavailabl
         target-repo directive both appended.
     """
     # Arrange
-    def raise_unavailable(_number, repo=None):
+    def raise_unavailable(_number, repo=None, review=None):
         raise GhUnavailable("gh state probe failed")
 
     monkeypatch.setattr(pr_state, "dispatch", raise_unavailable)
@@ -879,7 +975,7 @@ async def test_sdlc_implement_should_omit_target_repo_when_resolve_unavailable(m
         It should return the fresh skill with no "Target repo" directive.
     """
     # Arrange
-    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None: None)
+    monkeypatch.setattr(pr_state, "dispatch", lambda number, repo=None, review=None: None)
     _patch_resolve_repo_unavailable(monkeypatch)
 
     # Act


### PR DESCRIPTION
## Summary

Re-source the `sdlc_implement` feedback path from local `.sdlc/reviews/issue-#<N>/review-<iteration>.md` documents instead of live GitHub review threads. Once `sdlc_review` stopped posting to GitHub, `dispatch`'s detection of unresolved review threads no longer saw any findings, severing the remediation loop; this change reconnects it by reading the consolidated review document off disk.

Add a polymorphic `review: int | str | None` selector to `sdlc_implement` and `pr_state.dispatch`. With `review` omitted, `dispatch` loads the latest local review document for the closing issue when one exists and otherwise preserves the legacy classification (a linked PR yields the continue flow, a bare issue yields the fresh flow). An `int` selects an explicit iteration and surfaces a missing one as a clear `ValueError` rather than silently falling back. A `str` is treated as a GitHub PR URL: its review threads and review-body comments are converted into a brand-new local review document at the next iteration and then consumed. The existing GraphQL `reviewThreads` plus PR-body-comment fetch logic is kept and repurposed as that converter rather than deleted, so GitHub feedback still reaches the loop — but only through an explicit, inspectable conversion, never through implicit thread detection.

The dispatcher prefers local-document lookups, which need no `gh` round-trip: when `number` names an issue it speculatively reads the local document keyed on that issue before paying for classification, so the common feedback case stays offline. `dispatch` now returns `ReviewFindings` (parsed from a document) on the feedback path in place of the old GitHub-sourced `Findings`, and the server renders that into the `implement-feedback` prompt. The three implement prompts and the `AGENTS.md` / `README.md` docs are rewritten to describe document-sourced remediation, the `--review` selector, and the removal of implicit thread detection.

Closes #17

## Proposed changes

### Parse local review documents into `ReviewFindings` (`pr_state.py`)

Add frozen `ReviewFinding` and `ReviewFindings` dataclasses modeling a parsed review document — its issue number, iteration, source path, and ordered findings (each carrying an id, `blocking`/`advisory` severity, reference, issue text, remediation block, and optional touched commit). `ReviewFindings.format` renders the document into a human-readable feedback block, emitting a header (issue, iteration, path) followed by findings ordered blocking-first. Add `parse_review_document`, which splits the markdown on its `## Tier 1 — Blocking` / `## Tier 2 — Advisory` section boundaries and per-finding `### <ID> — <title>` headings, deriving severity from the enclosing tier with the `**(BLOCKING)**` heading marker as a corroborating signal, and extracting each finding's reference, issue text (a labelled `**Issue:**` paragraph for blocking findings, or the bare paragraph between the reference line and the first checkbox for advisory findings), remediation checklist, and touched commit.

### Locate and load review documents by iteration (`pr_state.py`)

Add the iteration helpers `_reviews_dir`, `_iterations`, `_latest_iteration`, and `_next_iteration`, which mirror the cwd-relative `.sdlc/reviews/issue-#<N>` convention `sdlc_review` writes to and parse the trailing integer from each `review-<n>.md` filename. Add `load_review_findings`, which loads the latest iteration by default or an explicit one when given, raising a descriptive `ValueError` when the directory is absent, holds no review document, or the requested iteration is missing. Add `_try_local_review`, a non-raising lookup that returns `None` on a missing directory or iteration so callers can fall through to a `gh`-based path.

### Convert a GitHub PR's review feedback into a local document (`pr_state.py`)

Add `convert_pr_review_to_document`, which parses `owner/repo/<number>` from a GitHub PR URL (rejecting any non-PR-URL string via the `_PR_URL` pattern so a numeric string is never coerced into an iteration), resolves the PR's closing issue, fetches its unresolved review threads and non-empty review-body comments, renders them into a template-shaped markdown document at the next iteration via `_render_github_findings_as_document`, writes it without overwriting an existing round, then parses it back. GitHub review feedback carries no severity, so every converted finding lands in the blocking tier with a generic pre-selected "address the reviewer's comment" remediation plus an `Other:` slot. Raise `ValueError` when the PR closes no issue, since there is no issue directory to write under.

### Rewrite `dispatch` around the `review` selector (`pr_state.py`)

Add the `review: int | str | None` parameter and change the feedback return type from `Findings` to `ReviewFindings`. A `str` short-circuits to a PR-URL conversion independent of `number`'s classification. Otherwise `dispatch` speculatively tries a local lookup keyed on `number` before classifying it, returning immediately on a hit. On a miss it classifies `number`, resolves the closing issue (the issue itself, or a PR's `closingIssuesReferences`), and — for an explicit iteration — loads it through `load_review_findings`, raising a clear `ValueError` when the PR closes no issue or the iteration is missing. With no explicit selector it retries the local lookup against the resolved closing issue, and only when no document exists does it fall back to the legacy `PrContext` (continue) or `None` (fresh) outcomes. The unconditional GitHub `reviewThreads` query is removed from the dispatch path; a linked PR with no local document now always yields `PrContext` rather than GitHub-sourced `Findings`.

### Thread the `review` selector through `sdlc_implement` (`server.py`)

Add the `review: int | str | None` parameter to the `sdlc_implement` tool, document its three modes, and pass it to `pr_state.dispatch`. Route the feedback branch on `isinstance(state, pr_state.ReviewFindings)` and render the document via `state.format()`. Catch `ValueError` from `dispatch` and return a clear "Could not load the requested review feedback" diagnostic string rather than propagating, so a missing iteration or malformed PR URL surfaces as readable tool output.

### Rewrite the implement prompts around local review documents (`skills/`)

Update `implement-feedback.md` to consume the rendered local-document block: re-read the named `.sdlc/reviews/issue-#<N>/review-<iteration>.md` to verify findings (replacing the GitHub `reviewThreads` + `reviews` re-query), resolve the PR branch from the closing issue (the block names `#<N>`, not the branch), enumerate the document's blocking/advisory tiers in place of GitHub `isResolved` state, restate each finding by its `Reference` (which may be `file:line`, a whole-file path, or an issue-level reference), and present the document's pre-selected `[x]` remediation as the recommended option. Update the stale-finding guidance to handle a superseding newer iteration instead of a GitHub-resolved thread. Update `implement.md` and `implement-continue.md` to describe dispatch keyed on PR state and the `--review` selector, and to route a selected local document to `implement-feedback`.

### Document the document-sourced remediation loop (`AGENTS.md`, `README.md`)

Update the `sdlc_implement` tool descriptions, the three-prompt dispatch summary, the `--review` selector semantics, and the `.sdlc/reviews/` convention to state that `sdlc_implement` consumes the latest local review document by default, that `--review <int>` selects an iteration and `--review <pr-url>` converts GitHub feedback into a fresh document, and that the dispatcher no longer probes GitHub review threads.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `test_pr_state` | Number 99 classifies as an issue and no PR closes it | `dispatch(99)` is called | Returns `None` for the fresh-implementation flow | `dispatch` fresh path |
| 2 | `test_pr_state` | An issue whose linked PR is 42 and no local review document on disk | `dispatch(99)` is called | Returns a `PrContext` carrying the linked PR's metadata | `dispatch` continue path via linked PR |
| 3 | `test_pr_state` | Number 42 classifies as a PR whose closing issue 7 has no local document | `dispatch(42)` is called with the default selector | Returns a `PrContext` carrying the PR's own metadata | `dispatch` continue path via PR number |
| 4 | `test_pr_state` | Issue 7 has a local `review-1.md` with a blocking finding | `dispatch(7)` is called with the default selector | Returns the parsed `ReviewFindings` with no `gh` round-trip | `dispatch` default local-document load |
| 5 | `test_pr_state` | Issue 7 has `review-1.md` and `review-2.md` | `dispatch(7, review=1)` is called | Returns the iteration-1 `ReviewFindings`, not the latest | `dispatch` explicit-iteration selection |
| 6 | `test_pr_state` | Issue 7 has only `review-1.md` | `dispatch(7, review=9)` is called | Raises `ValueError` rather than silently falling back | `dispatch` missing-iteration guard |
| 7 | `test_pr_state` | A GitHub PR URL whose PR closes issue 7 and carries review feedback | `dispatch` is called with that PR URL as `review` | Writes and returns the converted `ReviewFindings` | `dispatch` PR-URL conversion path |
| 8 | `test_pr_state` | A numeric string that is not a GitHub PR URL | `dispatch(42, review="123")` is called | Raises `ValueError` rather than coercing it to an iteration | `dispatch` PR-URL validation |
| 9 | `test_pr_state` | Number 999 fails both the pr-view and issue-view probes | `dispatch(999)` is called | Raises `GhUnavailable` | `dispatch` unknown-number handling |
| 10 | `test_pr_state` | `gh repo view` returns a non-zero exit | `dispatch(42)` is called | Raises `GhUnavailable` | `dispatch` gh-failure propagation |
| 11 | `test_pr_state` | The repo is a fork of `upstream/sdlc` and PR 42 closes issue 7 with no local document | `dispatch(42)` is called | Routes subsequent `gh` calls to `--repo upstream/sdlc` and returns a `PrContext` | `dispatch` fork routing |
| 12 | `TestReviewFindings` | `ReviewFindings` carrying one blocking finding | `format()` is called | The output includes the issue/iteration header and the finding's id, severity, reference, title, and remediation | `ReviewFindings.format` rendering |
| 13 | `TestReviewFindings` | `ReviewFindings` whose list holds an advisory finding before a blocking one | `format()` is called | The blocking finding appears before the advisory finding | `ReviewFindings.format` ordering |
| 14 | `test_pr_state` | A review document with one blocking finding under Tier 1 | `parse_review_document` is called | Returns a finding with the id, title with the BLOCKING marker stripped, blocking severity, reference, issue, remediation, and touched commit | `parse_review_document` blocking finding |
| 15 | `test_pr_state` | A Tier 2 advisory finding with a bare issue paragraph and unlabelled remediation | `parse_review_document` is called | Classifies the finding as advisory and captures the bare issue text and the remediation checklist | `parse_review_document` advisory finding |
| 16 | `test_pr_state` | A blocking finding whose `Reference` is an issue acceptance criterion | `parse_review_document` is called | Preserves the issue-level reference verbatim | `parse_review_document` issue-level reference |
| 17 | `test_pr_state` | A review document with one finding under each severity tier | `parse_review_document` is called | Returns both findings with the severity of their enclosing tier | `parse_review_document` tier grouping |
| 18 | `test_pr_state` | Two blocking findings under Tier 1 separated by a `---` horizontal rule | `parse_review_document` is called | Returns both findings and no remediation absorbs the `---` separator | `parse_review_document` adjacent-finding split |
| 19 | `test_pr_state` | A working directory with no `.sdlc/reviews/issue-#7` directory | `load_review_findings(7)` is called | Raises `ValueError` naming the missing directory | `load_review_findings` missing-directory guard |
| 20 | `test_pr_state` | Issue 7 has `review-1.md` and `review-2.md`, the latter naming finding B2 | `load_review_findings(7)` is called with no explicit iteration | Loads `review-2.md` and reports iteration 2 | `load_review_findings` latest-iteration load |
| 21 | `test_pr_state` | Issue 7 has `review-1.md` and `review-2.md` | `load_review_findings(7, iteration=1)` is called | Loads `review-1.md` regardless of the later iteration | `load_review_findings` explicit-iteration load |
| 22 | `test_pr_state` | Issue 7 has only `review-1.md` | `load_review_findings(7, iteration=5)` is called | Raises `ValueError` naming the missing iteration | `load_review_findings` missing-iteration guard |
| 23 | `test_pr_state` | Issue 7's review directory exists but contains no `review-<n>.md` file | `load_review_findings(7)` is called | Raises `ValueError` noting the directory has no review document | `load_review_findings` empty-directory guard |
| 24 | `test_pr_state` | A PR URL whose review feedback resolves to one thread and one review-body comment, closing issue 7 | `convert_pr_review_to_document` is called | Writes `review-1.md` under `issue-#7` and returns `ReviewFindings` carrying both converted findings | `convert_pr_review_to_document` round-trip |
| 25 | `test_pr_state` | Issue 7 already has `review-1.md`, and PR 42 closing issue 7 has review feedback | `convert_pr_review_to_document` is called | Writes `review-2.md` and leaves `review-1.md` untouched | `convert_pr_review_to_document` next-iteration write |
| 26 | `test_pr_state` | A string that is not a GitHub PR URL | `convert_pr_review_to_document` is called with it | Raises `ValueError` without touching `gh` | `convert_pr_review_to_document` URL validation |
| 27 | `test_pr_state` | A PR with two review-thread findings whose rendered document separates each block with a horizontal rule | `convert_pr_review_to_document` parses the document back | No finding's remediation captures the trailing `---` separator | `convert_pr_review_to_document` separator isolation |
| 28 | `test_server` | `pr_state.dispatch` returns a `ReviewFindings` instance | `sdlc_implement(number=42)` is called | Returns the feedback skill with the rendered review document appended | `sdlc_implement` feedback path |
| 29 | `test_server` | A captured dispatch spy and `review=3` | `sdlc_implement(number=7, review=3)` is called | `dispatch` receives `review=3` | `sdlc_implement` int-selector threading |
| 30 | `test_server` | A captured dispatch spy and a PR-URL review argument | `sdlc_implement(number=7, review=<pr-url>)` is called | `dispatch` receives the PR URL unchanged | `sdlc_implement` PR-URL threading |
| 31 | `test_server` | `pr_state.dispatch` raises `ValueError` for a missing review iteration | `sdlc_implement(number=7, review=9)` is called | Returns a clear diagnostic string rather than propagating | `sdlc_implement` ValueError handling |
| 32 | `test_server` | A non-fork repo and a PR whose closing issue has no local document, with real dispatch over canned `gh` | `sdlc_implement(number=42)` is called | `resolve_repo` is invoked exactly once and the result is reused across classification | `sdlc_implement` single repo resolution |
